### PR TITLE
Added suggestions for misspelled commands and added help option

### DIFF
--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -5,6 +5,8 @@ import chalk from 'chalk';
 import { isPlainObject, isBoolean, isString, set, difference } from 'lodash';
 import resolve from 'resolve';
 import leven from 'leven';
+import trimNewlines from 'trim-newlines';
+import redent from 'redent';
 
 import { merge } from '../configuration';
 import buildDocumentationObject from '../documentation/build-documentation-object';
@@ -236,7 +238,7 @@ export function generateCommandDocumentation({ settings }, { commands, settings:
     rows.push('');
 
     if (commands[command] && commands[command].help) {
-        rows.push(commands[command].help);
+        rows.push(redent(trimNewlines(commands[command].help)));
         rows.push('');
     }
 

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -120,7 +120,7 @@ function validateConfigurationStructure(config, applicationConfig) {
     return info.join('\n');
 }
 
-function getSuggestions(current, possible, command = false) {
+export function getSuggestions(current, possible, command = false) {
     const info = [];
 
     current.forEach((currentKey) => {
@@ -210,7 +210,7 @@ export function generateCommandsDocumentation({ commands }, { commands: commands
     });
 }
 
-function getCommandOptionsAsString(command) {
+function getCommandOptionsAsString(command = {}) {
     let options = '';
     (command.options || []).forEach((option) => {
         options += option.required ? `<${option.name}> ` : `[${option.name}] `;
@@ -227,24 +227,30 @@ function getCommandOptionsAsString(command) {
  * @param {object} config - the configuration object to generate documentation for
  * @param {object} metaConfig - the meta configuration object that has information about the configuration object
  * @param {string} command - the current command to show information about
+ * @param {string} name - the current command line program
  * @returns {string} The documentation as a string.
  */
-export function generateCommandDocumentation({ settings }, { commands, settings: meta }, command) {
+export function generateCommandDocumentation({ settings }, { commands, settings: meta }, command, name) {
     const rows = [];
-    rows.push('Usage: roc ' + command + ' ' + getCommandOptionsAsString(commands[command]));
+    rows.push('Usage: ' + name + ' ' + command + ' ' + getCommandOptionsAsString(commands[command]));
     rows.push('');
 
-    // Only continue if the command accepts settings
-    if (commands[command] && !commands[command].settings) {
-        return rows.join('\n');
+    if (commands[command] && commands[command].help) {
+        rows.push(commands[command].help);
+        rows.push('');
     }
 
-    rows.push('Options:');
-    rows.push('');
+    let documentationObject = [];
 
     // Generate the options table
-    const filter = (commands[command].settings === true) ? [] : commands[command].settings;
-    const documentationObject = buildDocumentationObject(settings, meta, filter);
+    if (commands[command] && commands[command].settings) {
+        rows.push('Options:');
+        rows.push('');
+
+        const filter = (!commands[command].settings === true) ? [] : commands[command].settings;
+        documentationObject = buildDocumentationObject(settings, meta, filter);
+    }
+
     const header = {
         cli: true,
         description: {
@@ -270,7 +276,7 @@ export function generateCommandDocumentation({ settings }, { commands, settings:
     };
 
     documentationObject.push({
-        name: 'Additional options',
+        name: 'CLI options',
         objects: [{
             cli: '-h, --help',
             description: 'Output usage information.'
@@ -293,7 +299,7 @@ export function generateCommandDocumentation({ settings }, { commands, settings:
 
     rows.push(generateTable(documentationObject, header, {
         compact: true,
-        titleWrapper: (name) => name + ':',
+        titleWrapper: (input) => input + ':',
         cellDivider: '',
         rowWrapper: (input) => `${input}`,
         header: false,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -16,7 +16,8 @@ import {
     generateCommandDocumentation,
     parseOptions,
     getMappings,
-    parseArguments
+    parseArguments,
+    getSuggestions
 } from './helpers';
 
 export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfig, initalMeta, args = process.argv) {
@@ -52,13 +53,14 @@ export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfi
 
     // If the command does not exist show error
     if (!extensionConfig.commands || !extensionConfig.commands[command]) {
-        return console.log(chalk.red('Invalid command: ' + chalk.bold(command) + '\n'));
+        console.log(chalk.bgRed('Invalid command'), '\n');
+        return console.log(getSuggestions([command], Object.keys(extensionConfig.commands)), '\n');
     }
 
     // Show command help information if requested
     if (help || h) {
         // TODO extensionConfig vs configObject
-        return console.log(generateCommandDocumentation(extensionConfig, metaObject, command));
+        return console.log(generateCommandDocumentation(extensionConfig, metaObject, command, info.name));
     }
 
     const parsedOptions = parseOptions(command, metaObject.commands, options);


### PR DESCRIPTION
Will now try to give a suggestion when a command is misspelled and possible to add a longer help text to the help output.
