### PR TITLE
Fixed incorrect logic when checking for filter value

### DIFF
--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -249,7 +249,8 @@ export function generateCommandDocumentation({ settings }, { commands, settings:
         rows.push('Options:');
         rows.push('');
 
-        const filter = (!commands[command].settings === true) ? [] : commands[command].settings;
+        const filter = commands[command].settings === true ? [] : commands[command].settings;
+
         documentationObject = buildDocumentationObject(settings, meta, filter);
     }
 


### PR DESCRIPTION
This bug meant that we would output the wrong information when using `--help` for a command.
