### PR TITLE
Changed command signature to take in an object

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -88,5 +88,11 @@ export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfi
     }
 
     // Run the command
-    return configObject.commands[command](debugEnabled, configObject, metaObject, extensionConfig, parsedOptions);
+    return configObject.commands[command]({
+        debug: debugEnabled,
+        configObject,
+        metaObject,
+        extensionConfig,
+        parsedOptions
+    });
 }


### PR DESCRIPTION
This will make it easier for commands in extensions to only use what they need.
