### PR TITLE
Adds the possibility to add general options to commands + new commands for init

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -21,6 +21,17 @@ runCli({
             help: `
                 Used to init new projects using special templates. If no template is given a prompt...
                 The templates are fetched from Github and it's easy to create new ones.`,
+            options: [{
+                name: 'list',
+                shortname: 'l',
+                validation: validators.isBoolean,
+                description: 'List the available versions of a template.'
+            }, {
+                name: 'force',
+                shortname: 'f',
+                validation: validators.isBoolean,
+                description: 'Ignore non empty directory warning.'
+            }],
             arguments: [{
                 name: 'template',
                 validation: validators.isPath,

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,12 +18,17 @@ runCli({
     commands: {
         init: {
             description: 'Init a new project.',
-            options: [{
+            help: `
+                Used to init new projects using special templates. If no template is given a prompt...
+                The templates are fetched from Github and it's easy to create new ones.`,
+            arguments: [{
                 name: 'template',
-                validation: validators.isPath
+                validation: validators.isPath,
+                description: 'What template to use. Matches Github structure with Username/Repo.'
             }, {
                 name: 'version',
-                validation: validators.isString
+                validation: validators.isString,
+                description: 'What version to use.'
             }]
         }
     }

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,7 +19,7 @@ runCli({
         init: {
             description: 'Init a new project.',
             help: `
-                Used to init new projects using special templates. If no template is given a prompt...
+                Used to init new projects using special templates. If no template is given a prompt will ask for one.
                 The templates are fetched from Github and it's easy to create new ones.`,
             options: [{
                 name: 'list',

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -22,13 +22,13 @@ The file should export an object that can contain the following properties:
 ```
 roc COMMAND --directory path/to/directory
 ```
-You can override the current working directory using the `-d, --directory` flag. The path can be either relative to the current working directory or absolute.
+You can override the current working directory using the `-d, --directory` option. The path can be either relative to the current working directory or absolute.
 
 ### Override configuration file
 ```
 roc COMMAND --config path/to/roc.config.js
 ```
-You can override the current the location and name for the `roc.config.js` file using the `-c, --config` flag. The path can be either relative to the current working directory or absolute.
+You can override the current the location and name for the `roc.config.js` file using the `-c, --config` option. The path can be either relative to the current working directory or absolute.
 
 ## Configuration in extensions
 The section above talked about how configuration files are managed in applications but it holds mostly true for extensions as well. They follow the same structure in `roc.config.js`; however they must manually be managed, meaning they can basically be called anything and be located anywhere.

--- a/docs/config/commands.md
+++ b/docs/config/commands.md
@@ -32,6 +32,7 @@ debug               If debug mode has been enabled
 configObject        The final configuration object where everything has been merged
 metaObject          The final meta configuration object where everything has been merged
 extensionConfig     The configuration object where all extensions has been merged
+parsedArguments     The parsed arguments given to the cli
 parsedOptions       The parsed options given to the cli
 ```
 
@@ -47,7 +48,7 @@ Will contain the final meta configuration object. This means that the applicatio
 ### extensionConfig
 The configuration object where all extensions has been merged. This means that this does not contain the application configuration or settings set in the cli.
 
-### parsedOptions
+### parsedArguments
 An object with the following properties:
 ```
 arguments           Object with the parsed arguments from the cli as key-value
@@ -56,13 +57,23 @@ rest                Arguments that was not matched with anything
 
 What arguments that are parsed is defined by the related meta object for the command. See below for more information.
 
+### parsedOptions
+An object with the following properties:
+```
+options             Object with the parsed options from the cli as key-value
+rest                Options that was not matched with anything
+```
+
+What options that are parsed is defined by the related meta object for the command. See below for more information.
+
 ## Meta
 
 Meta for commands are used to better define what they should do and describe what they are used for. It is optional but if used it should match the command properties. The following properties will be used by Roc if they exists:
 ```
 description         Describes the command
 help                Additional information used when printing help for a single command
-options             Options object that define what arguments/options the command uses
+options             Command line options that the command uses that are not part of the settings
+arguments           Arguments object that define what arguments the command uses
 settings            What roc settings the command uses, can either be true or an array with groups
 ```
 
@@ -70,28 +81,59 @@ settings            What roc settings the command uses, can either be true or an
 A string that describes what the command does. Used when printing general information about all the possible commands.
 
 ### help
-Used when printing information about a specific command. The input is reindented and starting/ending newlines are trimmed which means you can use a template literal without having to care about using the correct amount of indent.
+Used when printing information about a specific command. The input is reindented and starting/ending newlines are trimmed which means you can use a template literal without having to care about using the correct amount of indent. If no help is provided the description will be used instead.
 
-### options
+### arguments
 An array of objects that can have the following properties:
 ```
 name                The name of the option
 validation          A validation function that should return true if valid or false/error string if not
 required            If the option is required
+description         A text that describes how the option can be used
 ```
 
 The order of the objects in the array matter, they are parsed in the same order.
 
 #### name
-The name of the option. Will be used for in the cli for information and as the name of the value [parsedOptions](#parsedOptions).
+The name of the argument. Will be used for in the cli for information and as the name of the value [parsedArguments](#parsedArguments).
 
 #### validation
 Roc assumes that the validators used is either a RegExp or a function that will return true if it's valid or false/error string if it's not.
 
-For convenience several types of validators exists in `roc` that can be imported from `roc/validators`. For a complete list of them please see [the JSDocs](#).
+For convenience several types of validators exists in `roc` that can be imported from `roc/validators`. For a complete list of them please see [the JSDocs](/docs/JSDocs.md).
 
 #### required
 Set to true if the option is required.
+
+#### description
+Describes what it can be used for.
+
+### options
+An array of objects that can have the following properties:
+```
+name                The name of the option, will be used as '--name'
+shortname           The shortname for the option, will be used as '-shortname' and should be a single character
+validation          A validation function that should return true if valid or false/error string if not
+required            If the option is required
+description         A text that describes how the option can be used
+```
+
+#### name
+The name of the option. Will be used for in the cli for information and as the name of the value [parsedOptions](#parsedOptions).
+
+#### shortname
+The shortname of the option. Should be a single character long.
+
+#### validation
+Roc assumes that the validators used is either a RegExp or a function that will return true if it's valid or false/error string if it's not.
+
+For convenience several types of validators exists in `roc` that can be imported from `roc/validators`. For a complete list of them please see [the JSDocs](/docs/JSDocs.md).
+
+#### required
+Set to true if the option is required.
+
+#### description
+Describes what it can be used for.
 
 ### settings
 What roc settings the command uses, can either be true or an array with strings of the groups to use. Will determine what information the cli outputs, what it parses and what it validates.

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -8,7 +8,8 @@ import trimNewlines from 'trim-newlines';
 import redent from 'redent';
 
 import { merge } from '../configuration';
-import buildDocumentationObject from '../documentation/build-documentation-object';
+import keyboardDistance from './keyboard-distance';
+import buildDocumentationObject, { sortOnProperty } from '../documentation/build-documentation-object';
 import generateTable from '../documentation/generate-table';
 import { getDefaultValue } from '../documentation/helpers';
 import { fileExists, getRocDependencies, getPackageJson } from '../helpers';
@@ -60,7 +61,7 @@ export function buildCompleteConfig(
         }
 
         if (usedExtensions.length && debug) {
-            console.log(importantLabel('The following Roc extensions will be used:'), usedExtensions, '\n');
+            console.log(importantLabel('The following Roc extensions will be used:'), usedExtensions);
         }
 
         // Check for a mismatch between application configuration and extensions.
@@ -132,11 +133,11 @@ function validateConfigurationStructure(config, applicationConfig) {
  *
  * @param {string[]} current - The current values that might be incorrect.
  * @param {string[]} possible - All the possible correct values.
- * @param {boolean} [command=false] - If the suggestion should be managed as a command.
+ * @param {string} [prefix=''] - Something that the suggestion should be prefixed with. Useful for CLI options.
  *
  * @returns {string} - A string with possible suggestions for typos.
  */
-export function getSuggestions(current, possible, command = false) {
+export function getSuggestions(current, possible, prefix = '') {
     const info = [];
 
     current.forEach((currentKey) => {
@@ -158,12 +159,11 @@ export function getSuggestions(current, possible, command = false) {
             shortest = distance;
         }
 
-        const extra = command ? '--' : '';
         if (closest) {
-            info.push('Did not understand ' + chalk.underline(extra + currentKey) +
-                ' - Did you mean ' + chalk.underline(extra + closest));
+            info.push('Did not understand ' + chalk.underline(prefix + currentKey) +
+                ' - Did you mean ' + chalk.underline(prefix + closest));
         } else {
-            info.push('Did not understand ' + chalk.underline(extra + currentKey));
+            info.push('Did not understand ' + chalk.underline(prefix + currentKey));
         }
     });
 
@@ -189,9 +189,10 @@ export function generateCommandsDocumentation({ commands }, { commands: commands
 
     let body = [{
         name: 'Commands',
+        level: 0,
         objects: Object.keys(commands || noCommands).map((command) => {
             const options = commandsMeta[command] ?
-                ' ' + getCommandOptionsAsString(commandsMeta[command]) :
+                ' ' + getCommandArgumentsAsString(commandsMeta[command]) :
                 '';
             const description = commandsMeta[command] && commandsMeta[command].description ?
                 commandsMeta[command].description :
@@ -204,16 +205,16 @@ export function generateCommandsDocumentation({ commands }, { commands: commands
         })
     }];
 
-    return generateCommandDocsHelper(body, header, 'Options', 'name');
+    return generateCommandDocsHelper(body, header, 'General options', 'name');
 }
 
-function getCommandOptionsAsString(command = {}) {
-    let options = '';
-    (command.options || []).forEach((option) => {
-        options += option.required ? `<${option.name}> ` : `[${option.name}] `;
+function getCommandArgumentsAsString(command = {}) {
+    let args = '';
+    (command.arguments || []).forEach((argument) => {
+        args += argument.required ? `<${argument.name}> ` : `[${argument.name}] `;
     });
 
-    return options;
+    return args;
 }
 
  /**
@@ -228,34 +229,78 @@ function getCommandOptionsAsString(command = {}) {
   */
 export function generateCommandDocumentation({ settings }, { commands = {}, settings: meta }, command, name) {
     const rows = [];
-    rows.push('Usage: ' + name + ' ' + command + ' ' + getCommandOptionsAsString(commands[command]));
+    rows.push('Usage: ' + name + ' ' + command + ' ' + getCommandArgumentsAsString(commands[command]));
     rows.push('');
 
-    if (commands[command] && commands[command].help) {
-        rows.push(redent(trimNewlines(commands[command].help)));
+    if (commands[command] && (commands[command].description || commands[command].help)) {
+        if (commands[command].help) {
+            rows.push(redent(trimNewlines(commands[command].help)));
+        } else {
+            rows.push(commands[command].description);
+        }
+
         rows.push('');
     }
 
     let body = [];
 
-    // Generate the options table
-    if (commands[command] && commands[command].settings) {
-        rows.push('Options:');
-        rows.push('');
+    // Generate the arguments table
+    if (commands[command] && commands[command].arguments) {
+        const objects = commands[command].arguments.map((argument) => {
+            return {
+                cli: `${argument.name}`,
+                description: `${argument.description && argument.description + '  ' || ''}` +
+                    `${argument.required && chalk.green('Required') + '  ' || ''}` +
+                    `${argument.validation ? chalk.dim('(' + argument.validation(null, true).type + ')') : ''}`
+            };
+        });
 
+        if (objects.length > 0) {
+            body = body.concat({
+                name: 'Arguments',
+                level: 0,
+                objects: objects
+            });
+        }
+    }
+
+    // Generate the options table
+    if (commands[command] && commands[command].options) {
+        const objects = commands[command].options.map((option) => {
+            return {
+                cli: option.shortname ? `-${option.shortname}, --${option.name}` : `--${option.name}`,
+                description: `${option.description && option.description + '  ' || ''}` +
+                    `${option.required && chalk.green('Required') + '  ' || ''}` +
+                    `${option.validation ? chalk.dim('(' + option.validation(null, true).type + ')') : ''}`
+            };
+        });
+
+        if (objects.length > 0) {
+            body = body.concat({
+                name: 'Command options',
+                level: 0,
+                objects: objects
+            });
+        }
+    }
+
+    // Generate the settings table
+    if (commands[command] && commands[command].settings) {
         const filter = commands[command].settings === true ? [] : commands[command].settings;
 
-        body = buildDocumentationObject(settings, meta, filter);
+        body = body.concat({
+            name: 'Settings options',
+            children: sortOnProperty('name', buildDocumentationObject(settings, meta, filter))
+        });
     }
 
     const header = {
         cli: true,
         description: {
-            name: 'Description',
             padding: false
         },
         defaultValue: {
-            name: 'Default',
+            padding: false,
             renderer: (input) => {
                 input = getDefaultValue(input);
 
@@ -269,10 +314,20 @@ export function generateCommandDocumentation({ settings }, { commands = {}, sett
 
                 return chalk.cyan(input);
             }
+        },
+        required: {
+            padding: false,
+            renderer: (input, object) => {
+                if (input && !object.defaultValue) {
+                    return chalk.green('Required');
+                }
+
+                return '';
+            }
         }
     };
 
-    rows.push(generateCommandDocsHelper(body, header, 'CLI options', 'cli'));
+    rows.push(generateCommandDocsHelper(body, header, 'General options', 'cli'));
 
     return rows.join('\n');
 }
@@ -280,6 +335,7 @@ export function generateCommandDocumentation({ settings }, { commands = {}, sett
 function generateCommandDocsHelper(body, header, options, name) {
     body.push({
         name: options,
+        level: 0,
         objects: [{
             [name]: '-h, --help',
             description: 'Output usage information.'
@@ -313,33 +369,37 @@ function generateCommandDocsHelper(body, header, options, name) {
 /**
  * Parses options and validates them.
  *
- * @param {string} command - The command to parse options for.
+ * @param {string} command - The command to parse arguments for.
  * @param {Object} commands - commands from {@link rocMetaConfig}.
- * @param {Object[]} options - Options parsed by minimist.
+ * @param {Object[]} args - Arguments parsed by minimist.
  *
  * @returns {Object} - Parsed options.
  * @property {object[]} options - The parsed options that was matched against the meta configuration for the command.
  * @property {object[]} rest - The rest of the options that could not be matched against the configuration.
  */
-export function parseOptions(command, commands, options) {
+export function parseArguments(command, commands, args) {
     // If the command supports options
-    if (commands[command] && commands[command].options) {
-        let parsedOptions = {};
-        commands[command].options.forEach((option, index) => {
-            const value = options[index];
+    if (commands[command] && commands[command].arguments) {
+        let parsedArguments = {};
+        commands[command].arguments.forEach((argument, index) => {
+            const value = args[index];
 
-            if (option.required && !value) {
-                throw new Error(`Required option "${option.name}" was not provided.`);
+            if (argument.required && !value) {
+                /* eslint-disable no-process-exit */
+                console.log(errorLabel('Arguments problem') +
+                    ` Required argument ${chalk.bold(argument.name)} was not provided.\n`);
+                process.exit(1);
+                /* eslint-enable */
             }
 
-            if (value && option.validation) {
-                const validationResult = isValid(value, option.validation);
+            if (value && argument.validation) {
+                const validationResult = isValid(value, argument.validation);
                 if (validationResult !== true) {
                     try {
-                        throwError(option.name, validationResult, value, 'option');
+                        throwError(argument.name, validationResult, value, 'argument');
                     } catch (err) {
-                        /* eslint-disable no-process-exit, no-console */
-                        console.log(errorLabel('Arguments problem') + ' An option was not valid.\n');
+                        /* eslint-disable no-process-exit */
+                        console.log(errorLabel('Arguments problem') + ' An argument was not valid.\n');
                         console.log(err.message);
                         process.exit(1);
                         /* eslint-enable */
@@ -347,18 +407,18 @@ export function parseOptions(command, commands, options) {
                 }
             }
 
-            parsedOptions[option.name] = value;
+            parsedArguments[argument.name] = value;
         });
 
         return {
-            options: parsedOptions,
-            rest: options.splice(Object.keys(parsedOptions).length)
+            arguments: parsedArguments,
+            rest: args.splice(Object.keys(parsedArguments).length)
         };
     }
 
     return {
-        options: undefined,
-        rest: options
+        arguments: undefined,
+        rest: args
     };
 }
 
@@ -370,7 +430,7 @@ export function parseOptions(command, commands, options) {
  *
  * @returns {Object} - Properties are the cli command without leading dashes that maps to a {@link rocMapObject}.
  */
-export function getMappings(documentationObject) {
+export function getMappings(documentationObject = []) {
     const recursiveHelper = (groups) => {
         let mappings = {};
 
@@ -437,33 +497,126 @@ function getConvertor(value, name) {
 }
 
 /**
- * Converts a set of arguments to {@link rocConfigSettings} object.
+ * Converts a set of options to {@link rocConfigSettings} object and command specific options.
  *
- * @param {Object} args - Arguments parsed from minimist.
+ * @param {Object} options - Options parsed from minimist.
  * @param {Object} mappings - Result from {@link getMappings}.
+ * @param {Object} command - A command.
  *
  * @returns {Object} - The mapped Roc configuration settings object.
  */
-export function parseArguments(args, mappings) {
-    const config = {};
-    const info = [];
+export function parseOptions(options, mappings, command) {
+    const configuration = {};
+    const infoSettings = [];
+    const infoOptions = [];
 
-    Object.keys(args).forEach((key) => {
+    let notManagedOptions = {};
+    let possibleCommandOptions = [];
+    let possibleCommandOptionsShort = [];
+    const parsedOptions = {
+        options: {},
+        rest: {}
+    };
+
+    const getName = (name) => name.length === 1 ? '-' + name : '--' + name;
+
+    // Always match settings options first
+    Object.keys(options).forEach((key) => {
         if (mappings[key]) {
-            const value = convert(args[key], mappings[key]);
-            set(config, mappings[key].path, value);
+            const value = convert(options[key], mappings[key]);
+            set(configuration, mappings[key].path, value);
         } else {
             // We did not find a match
-            info.push(getSuggestions([key], Object.keys(mappings), true));
+            notManagedOptions = {
+                ...notManagedOptions,
+                [key]: options[key]
+            };
         }
     });
 
-    if (info.length > 0) {
-        console.log(errorLabel('CLI problem'), 'Some commands were not understood.\n');
-        console.log(info.join('\n') + '\n');
+    if (command && command.options) {
+        possibleCommandOptions = command.options.map((option) => option.name);
+        possibleCommandOptionsShort = command.options.reduce((previous, option) => {
+            if (option.shortname) {
+                return previous.concat(option.shortname);
+            }
+
+            return previous;
+        }, []);
+
+        command.options.forEach((option) => {
+            let value;
+            let name;
+            if (notManagedOptions[option.name]) {
+                value = notManagedOptions[option.name];
+                delete notManagedOptions[option.name];
+                name = option.name;
+            } else if (notManagedOptions[option.shortname]) {
+                value = notManagedOptions[option.shortname];
+                delete notManagedOptions[option.shortname];
+                name = option.shortname;
+            }
+
+            if (option.required && !value) {
+                const getOptions = () => {
+                    const shortOption = option.shortname ? ' or ' + chalk.bold('-' + option.shortname) : '';
+                    return chalk.bold('--' + option.name) + shortOption;
+                };
+
+                infoOptions.push(`Required option ${getOptions()} was not provided.`);
+            }
+
+            if (value && option.validation) {
+                const validationResult = isValid(value, option.validation);
+                if (validationResult !== true) {
+                    try {
+                        throwError(getName(name), validationResult, value, 'option');
+                    } catch (err) {
+                        /* eslint-disable no-process-exit */
+                        console.log(errorLabel('Command options problem') + ' A option was not valid.\n');
+                        console.log(err.message);
+                        process.exit(1);
+                        /* eslint-enable */
+                    }
+                }
+            }
+
+            parsedOptions.options[option.name] = value;
+        });
     }
 
-    return config;
+    parsedOptions.rest = notManagedOptions;
+
+    const defaultOptions = ['help', 'config', 'debug', 'directory', 'version'];
+    const defaultOptionsShort = ['h', 'd', 'c', 'D', 'v'];
+
+    Object.keys(notManagedOptions).forEach((key) => {
+        if (key.length > 1) {
+            infoSettings.push(getSuggestions([key],
+                Object.keys(mappings).concat(defaultOptions, possibleCommandOptions), '--'));
+        } else {
+            infoSettings.push(getSuggestions([key],
+                [keyboardDistance(key, defaultOptionsShort.concat(possibleCommandOptionsShort))], '-'));
+        }
+    });
+
+    if (infoSettings.length > 0) {
+        console.log(errorLabel('Option problem'), 'Some options were not understood.\n');
+        console.log(infoSettings.join('\n') + '\n');
+    }
+
+    if (infoOptions.length > 0) {
+        console.log(errorLabel('Command options problem'), 'Some command options were not provided.\n');
+        console.log(infoOptions.join('\n') + '\n');
+        /* eslint-disable no-process-exit */
+        process.exit(1);
+        /* eslint-enable */
+    }
+
+    return {
+        configuration,
+        parsedOptions
+    };
 }
 
 function convert(value, mapping) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -84,11 +84,11 @@ export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfi
         documentationObject = buildDocumentationObject(configObject.settings, metaObject.settings, filter);
     }
 
-    const { configuration, parsedOptions } =
+    const { settings, parsedOptions } =
         parseOptions(restOptions, getMappings(documentationObject), metaObject.commands[command]);
 
     configObject = merge(configObject, {
-        settings: configuration
+        settings
     });
 
     // Validate configuration

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -27,15 +27,15 @@ import { error as styleError } from '../helpers/style';
  * @param {rocConfig} initalConfig - The inital configuration, will be merged with the selected extensions and
  *  application.
  * @param {rocMetaConfig} initalMeta - The inital meta configuration, will be merged with the selected extensions.
- * @param {string[]} [args=process.argv] - From where it should parse the arguments.
+ * @param {string[]} [argv=process.argv] - From where it should parse the arguments.
  *
  * @returns {undefined}
  */
-export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfig, initalMeta, args = process.argv) {
-    const {_, h, help, d, debug, v, version, c, config, D, directory, ...restArgs} = minimist(args.slice(2));
+export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfig, initalMeta, argv = process.argv) {
+    const {_, h, help, d, debug, v, version, c, config, D, directory, ...restOptions} = minimist(argv.slice(2));
 
     // The first should be our command if there is one
-    const [command, ...options] = _;
+    const [command, ...args] = _;
 
     // If version is selected output that and stop
     if (version || v) {
@@ -74,20 +74,25 @@ export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfi
         return console.log(generateCommandDocumentation(extensionConfig, metaObject, command, info.name));
     }
 
-    const parsedOptions = parseOptions(command, metaObject.commands, options);
+    const parsedArguments = parseArguments(command, metaObject.commands, args);
 
+    let documentationObject;
     // Only parse arguments if the command accepts it
     if (metaObject.commands[command] && metaObject.commands[command].settings) {
         // Get config from application and only parse options that this command cares about.
         const filter = metaObject.commands[command].settings === true ? [] : metaObject.commands[command].settings;
-        const documentationObject = buildDocumentationObject(configObject.settings, metaObject.settings, filter);
+        documentationObject = buildDocumentationObject(configObject.settings, metaObject.settings, filter);
+    }
 
-        const configuration = parseArguments(restArgs, getMappings(documentationObject));
-        configObject = merge(configObject, {
-            settings: configuration
-        });
+    const { configuration, parsedOptions } =
+        parseOptions(restOptions, getMappings(documentationObject), metaObject.commands[command]);
 
-        // Validate configuration
+    configObject = merge(configObject, {
+        settings: configuration
+    });
+
+    // Validate configuration
+    if (metaObject.commands[command] && metaObject.commands[command].settings) {
         validate(configObject.settings, metaObject.settings, metaObject.commands[command].settings);
     }
 
@@ -105,6 +110,7 @@ export function runCli(info = {version: 'Unknown', name: 'Unknown'}, initalConfi
         configObject,
         metaObject,
         extensionConfig,
+        parsedArguments,
         parsedOptions
     });
 }

--- a/src/cli/keyboard-distance.js
+++ b/src/cli/keyboard-distance.js
@@ -24,19 +24,16 @@ export default function keyboardDistance(char, possible) {
     ];
 
     const getPosition = (c) => {
-        let val = {};
-        qwerty.forEach((row, rowIndex) => {
-            row.forEach((column, columnIndex) => {
-                if (c.toLowerCase() === column) {
-                    val = {
-                        row: rowIndex + 1,
-                        column: columnIndex + 1
+        for (const rowIndex in qwerty) {
+            for (const columnIndex in qwerty[rowIndex]) {
+                if (c.toLowerCase() === qwerty[rowIndex][columnIndex]) {
+                    return {
+                        row: parseInt(rowIndex, 10) + 1,
+                        column: parseInt(columnIndex, 10) + 1
                     };
                 }
-            });
-        });
-
-        return val;
+            }
+        }
     };
 
     const map = possible.map((p) => {

--- a/src/cli/keyboard-distance.js
+++ b/src/cli/keyboard-distance.js
@@ -1,0 +1,70 @@
+/**
+ * Can be used to calculate the closest character from a list of possible one for a single character.
+ *
+ * Assumes that the keyboard that is used is a Qwerty keyboard.
+ *
+ * Used to guess the correct character for a cli option.
+ *
+ * @param {string} char - The character to find the closest match for.
+ * @param {string[]} possible - The list of possible characters.
+ *
+ * @returns {string} - The closest match.
+ */
+export default function keyboardDistance(char, possible) {
+    if (char.length > 1) {
+        throw new Error('First argument must be a single character.');
+    }
+
+    possible = possible || [];
+    const qwerty = [
+        ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+        ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+        ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
+        ['z', 'x', 'c', 'v', 'b', 'n', 'm']
+    ];
+
+    const getPosition = (c) => {
+        let val = {};
+        qwerty.forEach((row, rowIndex) => {
+            row.forEach((column, columnIndex) => {
+                if (c.toLowerCase() === column) {
+                    val = {
+                        row: rowIndex + 1,
+                        column: columnIndex + 1
+                    };
+                }
+            });
+        });
+
+        return val;
+    };
+
+    const map = possible.map((p) => {
+        return Object.assign({}, { name: p }, getPosition(p));
+    });
+
+    const getDistance = (a, b) => {
+        const minRow = Math.abs(a.row - b.row);
+        const minColumn = Math.abs(a.column - b.column);
+
+        return minRow > minColumn ? minRow : minColumn;
+    };
+
+    const currentKey = getPosition(char);
+
+    let shortest = -1;
+    let closest;
+
+    for (let key of map) {
+        const distance = getDistance(currentKey, key);
+
+        if (shortest > -1 && distance >= shortest) {
+            continue;
+        }
+
+        closest = key;
+        shortest = distance;
+    }
+
+    return closest.name;
+}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -32,8 +32,8 @@ const templates = [{
  *
  * @returns {Promise} - Promise for the command.
  */
-export default function init({ parsedOptions }) {
-    const { template, version } = parsedOptions.options;
+export default function init({ parsedArguments }) {
+    const { template, version } = parsedArguments.arguments;
 
     // Make sure the directory is empty!
     assertEmptyDir();

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -32,11 +32,12 @@ const templates = [{
  *
  * @returns {Promise} - Promise for the command.
  */
-export default function init({ parsedArguments }) {
+export default function init({ parsedArguments, parsedOptions }) {
+    const { list, force } = parsedOptions.options;
     const { template, version } = parsedArguments.arguments;
 
     // Make sure the directory is empty!
-    assertEmptyDir();
+    assertEmptyDir(force);
 
     if (!template) {
         return interativeMenu();
@@ -64,6 +65,14 @@ export default function init({ parsedArguments }) {
             .then((versions) => {
                 // Add master so we always have a way to install it
                 versions.push({name: 'master'});
+
+                if (list) {
+                    console.log('The available versions are:');
+                    console.log(Object.keys(versions).map((index) => ` ${versions[index].name}`).join('\n'));
+                    /* eslint-disable no-process-exit */
+                    process.exit(0);
+                    /* eslint-enable */
+                }
 
                 // If the name starts with a number we will automatically add 'v' infront of it to match Github default
                 if (selectVersion && !isNaN(Number(selectVersion.charAt(0))) && selectVersion.charAt(0) !== 'v') {
@@ -111,7 +120,7 @@ export default function init({ parsedArguments }) {
             })
             .catch((error) => {
                 console.log(styleError('\nAn error occured during init!\n'));
-                console.error(error.stack);
+                console.error(error.message);
                 /* eslint-disable no-process-exit */
                 process.exit(1);
                 /* eslint-enable */
@@ -188,8 +197,8 @@ export default function init({ parsedArguments }) {
         });
     }
 
-    function assertEmptyDir() {
-        if (fs.readdirSync(process.cwd()).length > 0) {
+    function assertEmptyDir(ignoreNonEmpty = false) {
+        if (!ignoreNonEmpty && fs.readdirSync(process.cwd()).length > 0) {
             console.log(styleError('You need to call this command from an empty directory.'));
             /* eslint-disable no-process-exit */
             process.exit(1);

--- a/src/documentation/helpers.js
+++ b/src/documentation/helpers.js
@@ -29,13 +29,13 @@ export function addPadding(string, length) {
 }
 
 /**
- * Takes a configuration path array and convertes it to a cli flag.
+ * Takes a configuration path array and convertes it to a cli option.
  *
  * @param {string[]} configPaths - The configuration path, a array consiting of properties.
  *
- * @returns {string} - The cli flag to set the given configuration option.
+ * @returns {string} - The cli option to set the given configuration option.
  */
-export function toCliFlag(configPaths) {
+export function toCliOption(configPaths) {
     // Runtime should be added directly
     if (configPaths[0] === 'runtime') {
         configPaths.shift();

--- a/src/documentation/index.js
+++ b/src/documentation/index.js
@@ -2,7 +2,7 @@ import 'source-map-support/register';
 
 import { escape } from 'lodash';
 
-import buildDocumentationObject from '../documentation/build-documentation-object';
+import buildDocumentationObject, { sortOnProperty } from '../documentation/build-documentation-object';
 import generateTable from '../documentation/generate-table';
 import { pad, getDefaultValue } from '../documentation/helpers';
 import { error as styleError, warning, ok } from '../helpers/style';
@@ -17,7 +17,7 @@ import { error as styleError, warning, ok } from '../helpers/style';
  * @returns {string} - A markdown table as a string.
  */
 export function generateMarkdownDocumentation({ settings }, { settings: meta }, filter = []) {
-    const documentationObject = buildDocumentationObject(settings, meta, filter);
+    const documentationObject = sortOnProperty('name', buildDocumentationObject(settings, meta, filter));
 
     const header = {
         name: {
@@ -31,7 +31,7 @@ export function generateMarkdownDocumentation({ settings }, { settings: meta }, 
             name: 'Path'
         },
         cli: {
-            name: 'CLI Flag'
+            name: 'CLI option'
         },
         defaultValue: {
             name: 'Default',
@@ -67,7 +67,7 @@ export function generateMarkdownDocumentation({ settings }, { settings: meta }, 
  * @returns {string} - A table as a string.
  */
 export function generateTextDocumentation({ settings }, { settings: meta }, filter = []) {
-    const documentationObject = buildDocumentationObject(settings, meta, filter);
+    const documentationObject = sortOnProperty('name', buildDocumentationObject(settings, meta, filter));
 
     const header = {
         description: {
@@ -96,7 +96,7 @@ export function generateTextDocumentation({ settings }, { settings: meta }, filt
             }
         },
         cli: {
-            name: 'CLI Flag'
+            name: 'CLI option'
         },
         required: {
             name: 'Required',
@@ -109,5 +109,7 @@ export function generateTextDocumentation({ settings }, { settings: meta }, filt
         }
     };
 
-    return generateTable(documentationObject, header);
+    return generateTable(documentationObject, header, {
+        groupTitleWrapper: (name, level, parentNames) => parentNames.concat(name).join(' > ')
+    });
 }

--- a/test/cli/helpers.js
+++ b/test/cli/helpers.js
@@ -88,7 +88,7 @@ describe('roc', () => {
                             required: true
                         }]
                     })).toEqual({
-                        configuration: {},
+                        settings: {},
                         parsedOptions: {
                             options: { list: 'hello', test: true },
                             rest: {}

--- a/test/cli/helpers.js
+++ b/test/cli/helpers.js
@@ -4,12 +4,21 @@ import { join } from 'path';
 
 import { consoleMockWrapper } from '../utils';
 
-import { buildCompleteConfig, getSuggestions, getMappings } from '../../src/cli/helpers';
+import { isString } from '../../src/validation/validators';
+import {
+    buildCompleteConfig,
+    getSuggestions,
+    getMappings,
+    parseOptions,
+    parseArguments,
+    generateCommandsDocumentation,
+    generateCommandDocumentation
+} from '../../src/cli/helpers';
 
 import { complexDocumentObject } from '../documentation/data/documentation-object';
 
 describe('roc', () => {
-    describe('cli', () => {
+    describe('cli helpers', () => {
         describe('buildCompleteConfig', () => {
             let resolveSync;
 
@@ -38,6 +47,216 @@ describe('roc', () => {
             });
         });
 
+        describe('parseOptions', () => {
+            let exit;
+
+            beforeEach(() => {
+                exit = expect.spyOn(process, 'exit').andCall(() => {
+                    throw new Error('process exit called');
+                });
+            });
+
+            afterEach(() => {
+                exit.calls = [];
+                exit.restore();
+            });
+
+            it('should tell the user that a required option is missing', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseOptions).withArgs({
+                    }, {}, {
+                        options: [{
+                            name: 'list',
+                            required: true
+                        }]
+                    }).toThrow();
+                });
+            });
+
+            it('should correctly map the options', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseOptions({
+                        list: 'hello',
+                        t: true
+                    }, {}, {
+                        options: [{
+                            name: 'list',
+                            required: true
+                        }, {
+                            name: 'test',
+                            shortname: 't',
+                            required: true
+                        }]
+                    })).toEqual({
+                        configuration: {},
+                        parsedOptions: {
+                            options: { list: 'hello', test: true },
+                            rest: {}
+                        }
+                    });
+                });
+            });
+
+            it('should correctly validate the options', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseOptions).withArgs({
+                        list: 123
+                    }, {}, {
+                        options: [{
+                            name: 'list',
+                            validation: isString,
+                            required: true
+                        }]
+                    }).toThrow();
+                });
+            });
+        });
+
+        describe('parseArguments', () => {
+            let exit;
+
+            beforeEach(() => {
+                exit = expect.spyOn(process, 'exit').andCall(() => {
+                    throw new Error('process exit called');
+                });
+            });
+
+            afterEach(() => {
+                exit.calls = [];
+                exit.restore();
+            });
+
+            it('should tell the user that a required argument is missing', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseArguments).withArgs('test', {
+                        test: {
+                            arguments: [{
+                                name: 'version',
+                                required: true
+                            }]
+                        }
+                    }, []).toThrow();
+                });
+            });
+
+            it('should correctly map the options', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseArguments('test', {
+                        test: {
+                            arguments: [{
+                                name: 'version',
+                                validation: isString,
+                                required: true
+                            }]
+                        }
+                    }, ['value'])).toEqual({
+                        arguments: { version: 'value' },
+                        rest: []
+                    });
+                });
+            });
+
+            it('should correctly validate the arguments', () => {
+                return consoleMockWrapper(() => {
+                    expect(parseArguments).withArgs('test', {
+                        test: {
+                            arguments: [{
+                                name: 'version',
+                                validation: isString,
+                                required: true
+                            }]
+                        }
+                    }, [123]).toThrow();
+                });
+            });
+        });
+
+        describe('generateCommandsDocumentation', () => {
+            it('should correctly output documentation', () => {
+                expect(stripAnsi(generateCommandsDocumentation({
+                    commands: {
+                        test: () => {},
+                        help: () => {}
+                    }
+                }, {
+                    commands: {
+                        test: {
+                            description: 'This command will do awesome stuff!',
+                            arguments: [{
+                                name: 'version'
+                            }],
+                            options: [{
+                                name: 'list'
+                            }]
+                        }
+                    }
+                })).replace(/ +$/gm, '')).toEqual((
+                    /* eslint-disable max-len */
+`Commands:
+ test [version]   This command will do awesome stuff!
+ help
+
+General options:
+ -h, --help       Output usage information.
+ -v, --version    Output version number.
+ -d, --debug      Enable debug mode.
+ -c, --config     Path to configuration file, will default to roc.config.js in current working directory.
+ -D, --directory  Path to working directory, will default to the current working directory. Can be either absolute or relative.
+`
+                    /* eslint-enable */
+                ));
+            });
+        });
+
+        describe('generateCommandDocumentation', () => {
+            it('should correctly output documentation', () => {
+                expect(stripAnsi(generateCommandDocumentation({
+                    settings: {
+                        runtime: {
+                            port: 8080
+                        }
+                    }
+                }, {
+                    commands: {
+                        test: {
+                            description: 'This command will do awesome stuff!',
+                            settings: true,
+                            arguments: [{
+                                name: 'version'
+                            }],
+                            options: [{
+                                name: 'list'
+                            }]
+                        }
+                    }
+                }, 'test', 'roc')).replace(/ +$/gm, '')).toEqual((
+                    /* eslint-disable max-len */
+`Usage: roc test [version]
+
+This command will do awesome stuff!
+
+Arguments:
+ version
+
+Command options:
+ --list
+
+Settings options:
+runtime:
+ --port             8080
+
+General options:
+ -h, --help       Output usage information.
+ -v, --version    Output version number.
+ -d, --debug      Enable debug mode.
+ -c, --config     Path to configuration file, will default to roc.config.js in current working directory.
+ -D, --directory  Path to working directory, will default to the current working directory. Can be either absolute or relative.
+`
+                    /* eslint-enable */
+                ));
+            });
+        });
+
         describe('getSuggestions', () => {
             it('should suggest the best alternative spelling', () => {
                 const suggestion = getSuggestions(['te'], ['tea', 'test', 'testing']);
@@ -50,7 +269,7 @@ describe('roc', () => {
             });
 
             it('should add -- infront of suggestions if command is enabled', () => {
-                const suggestion = getSuggestions(['te'], ['test', 'tea', 'testing'], true);
+                const suggestion = getSuggestions(['te'], ['test', 'tea', 'testing'], '--');
                 expect(stripAnsi(suggestion)).toEqual('Did not understand --te - Did you mean --tea');
             });
         });

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -24,8 +24,11 @@ describe('roc', () => {
                 commands: {
                     test: {
                         settings: true,
-                        options: [{
+                        arguments: [{
                             name: 'artifact'
+                        }],
+                        options: [{
+                            name: 'list'
                         }]
                     }
                 }
@@ -79,7 +82,8 @@ describe('roc', () => {
                         configObject: config,
                         extensionConfig: config,
                         metaObject: meta,
-                        parsedOptions: { options: { artifact: undefined }, rest: [] }
+                        parsedArguments: { arguments: { artifact: undefined }, rest: [] },
+                        parsedOptions: { options: { list: undefined }, rest: {} }
                     });
                 });
             });
@@ -94,7 +98,8 @@ describe('roc', () => {
                         configObject: config,
                         extensionConfig: config,
                         metaObject: meta,
-                        parsedOptions: { options: { artifact: undefined }, rest: [] }
+                        parsedArguments: { arguments: { artifact: undefined }, rest: [] },
+                        parsedOptions: { options: { list: undefined }, rest: {} }
                     });
                 });
             });
@@ -119,7 +124,8 @@ describe('roc', () => {
                         configObject: newConfig,
                         extensionConfig: config,
                         metaObject: meta,
-                        parsedOptions: { options: { artifact: undefined }, rest: [] }
+                        parsedArguments: { arguments: { artifact: undefined }, rest: [] },
+                        parsedOptions: { options: { list: undefined }, rest: {} }
                     });
                 });
             });

--- a/test/cli/keyboard-distance.js
+++ b/test/cli/keyboard-distance.js
@@ -1,0 +1,21 @@
+import expect from 'expect';
+
+import keyboardDistance from '../../src/cli/keyboard-distance';
+
+describe('roc', () => {
+    describe('cli', () => {
+        describe('keyboardDistance', () => {
+            it('should throw error if first argument is not a single character', () => {
+                expect(keyboardDistance).withArgs('hello').toThrow();
+            });
+
+            it('should give back the same character if it´s one of the possible', () => {
+                expect(keyboardDistance('g', ['a', 'f', 'd', 'r', 'g', 'v'])).toBe('g');
+            });
+
+            it('should give back the clostest one', () => {
+                expect(keyboardDistance('g', ['a', 'f', 'd', 'e', 'w'])).toBe('f');
+            });
+        });
+    });
+});

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -66,7 +66,7 @@ describe('roc', () => {
 
                 return consoleMockWrapper((log) => {
                     expect(init)
-                        .withArgs({ parsedOptions: { options: {} } })
+                        .withArgs({ parsedArguments: { arguments: {} } })
                         .toThrow();
 
                     expect(log.calls[0].arguments[0]).toInclude('need to call this command from an empty');
@@ -77,7 +77,7 @@ describe('roc', () => {
                 readdirSync.andReturn([]);
 
                 return consoleMockWrapper(() => {
-                    init({ parsedOptions: { options: {} } });
+                    init({ parsedArguments: { arguments: {} } });
                     expect(prompt.calls[0].arguments[0][0].choices.length).toBe(2);
                 });
             });
@@ -87,7 +87,7 @@ describe('roc', () => {
 
                 return consoleMockWrapper((log) => {
                     expect(init)
-                        .withArgs({ parsedOptions: { options: { template: 'roc-template' } } })
+                        .withArgs({ parsedArguments: { arguments: { template: 'roc-template' } } })
                         .toThrow();
 
                     expect(log).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('roc', () => {
                 getVersions.andReturn(Promise.resolve(['1.0']));
                 get.andReturn(Promise.resolve(dirPath));
                 return consoleMockWrapper((log) => {
-                    return init({ parsedOptions: { options: { template: 'vgno/roc-template-web' } } })
+                    return init({ parsedArguments: { arguments: { template: 'vgno/roc-template-web' } } })
                         .then(() => {
                             expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),
                                 path.join(dirPath, 'template', '.roc'));
@@ -128,7 +128,7 @@ describe('roc', () => {
                 get.andReturn(Promise.resolve(path.join(__dirname, 'data', 'invalid-template')));
 
                 return consoleMockWrapper((log) => {
-                    return init({ parsedOptions: { options: { template: 'vgno/roc-template-web' } } })
+                    return init({ parsedArguments: { arguments: { template: 'vgno/roc-template-web' } } })
                         .catch((err) => {
                             if (err.message !== 'process exit called') {
                                 throw err;
@@ -150,7 +150,7 @@ describe('roc', () => {
                 getVersions.andReturn(Promise.resolve([{name: 'v1.0'}]));
                 get.andReturn(Promise.resolve(path.join(__dirname, 'data', 'valid-template')));
                 return consoleMockWrapper((log) => {
-                    return init({ parsedOptions: { options:
+                    return init({ parsedArguments: { arguments:
                             { template: 'vgno/roc-template-web', version: 'v1.0' } } })
                         .then(() => {
                             expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -66,7 +66,7 @@ describe('roc', () => {
 
                 return consoleMockWrapper((log) => {
                     expect(init)
-                        .withArgs({ parsedArguments: { arguments: {} } })
+                        .withArgs({ parsedArguments: { arguments: {} }, parsedOptions: { options: {} } })
                         .toThrow();
 
                     expect(log.calls[0].arguments[0]).toInclude('need to call this command from an empty');
@@ -77,7 +77,10 @@ describe('roc', () => {
                 readdirSync.andReturn([]);
 
                 return consoleMockWrapper(() => {
-                    init({ parsedArguments: { arguments: {} } });
+                    init({
+                        parsedArguments: { arguments: {} },
+                        parsedOptions: { options: {} }
+                    });
                     expect(prompt.calls[0].arguments[0][0].choices.length).toBe(2);
                 });
             });
@@ -87,7 +90,10 @@ describe('roc', () => {
 
                 return consoleMockWrapper((log) => {
                     expect(init)
-                        .withArgs({ parsedArguments: { arguments: { template: 'roc-template' } } })
+                        .withArgs({
+                            parsedArguments: { arguments: { template: 'roc-template' } },
+                            parsedOptions: { options: {} }
+                        })
                         .toThrow();
 
                     expect(log).toHaveBeenCalled();
@@ -105,20 +111,23 @@ describe('roc', () => {
                 getVersions.andReturn(Promise.resolve(['1.0']));
                 get.andReturn(Promise.resolve(dirPath));
                 return consoleMockWrapper((log) => {
-                    return init({ parsedArguments: { arguments: { template: 'vgno/roc-template-web' } } })
-                        .then(() => {
-                            expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),
-                                path.join(dirPath, 'template', '.roc'));
-                            expect(copySync).toHaveBeenCalledWith(path.join(dirPath, 'template'),
-                                process.cwd());
+                    return init({
+                        parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
+                        parsedOptions: { options: {} }
+                    })
+                    .then(() => {
+                        expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),
+                            path.join(dirPath, 'template', '.roc'));
+                        expect(copySync).toHaveBeenCalledWith(path.join(dirPath, 'template'),
+                            process.cwd());
 
-                            expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
-                            expect(spawn.calls[1].arguments[2].cwd).toEqual(process.cwd());
+                        expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                        expect(spawn.calls[1].arguments[2].cwd).toEqual(process.cwd());
 
-                            expect(log.calls[0].arguments[0]).toInclude('Installing template setup dependencies');
-                            expect(log.calls[1].arguments[0]).toInclude('Installing template dependencies');
-                            expect(log.calls[2].arguments[0]).toInclude('Setup completed');
-                        });
+                        expect(log.calls[0].arguments[0]).toInclude('Installing template setup dependencies');
+                        expect(log.calls[1].arguments[0]).toInclude('Installing template dependencies');
+                        expect(log.calls[2].arguments[0]).toInclude('Setup completed');
+                    });
                 });
             });
 
@@ -128,15 +137,17 @@ describe('roc', () => {
                 get.andReturn(Promise.resolve(path.join(__dirname, 'data', 'invalid-template')));
 
                 return consoleMockWrapper((log) => {
-                    return init({ parsedArguments: { arguments: { template: 'vgno/roc-template-web' } } })
-                        .catch((err) => {
-                            if (err.message !== 'process exit called') {
-                                throw err;
-                            }
+                    return init({
+                        parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
+                        parsedOptions: { options: {} }
+                    }).catch((err) => {
+                        if (err.message !== 'process exit called') {
+                            throw err;
+                        }
 
-                            expect(log.calls[0].arguments[0]).toInclude('this is not a Roc template');
-                            expect(exit).toHaveBeenCalledWith(1);
-                        });
+                        expect(log.calls[0].arguments[0]).toInclude('this is not a Roc template');
+                        expect(exit).toHaveBeenCalledWith(1);
+                    });
                 });
             });
 
@@ -150,21 +161,23 @@ describe('roc', () => {
                 getVersions.andReturn(Promise.resolve([{name: 'v1.0'}]));
                 get.andReturn(Promise.resolve(path.join(__dirname, 'data', 'valid-template')));
                 return consoleMockWrapper((log) => {
-                    return init({ parsedArguments: { arguments:
-                            { template: 'vgno/roc-template-web', version: 'v1.0' } } })
-                        .then(() => {
-                            expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),
-                                path.join(dirPath, 'template', '.roc'));
-                            expect(copySync).toHaveBeenCalledWith(path.join(dirPath, 'template'),
-                                process.cwd());
+                    return init({
+                        parsedArguments: { arguments:
+                            { template: 'vgno/roc-template-web', version: 'v1.0' } },
+                        parsedOptions: { options: {} }
+                    }).then(() => {
+                        expect(renameSync).toHaveBeenCalledWith(path.join(dirPath, 'package.json'),
+                            path.join(dirPath, 'template', '.roc'));
+                        expect(copySync).toHaveBeenCalledWith(path.join(dirPath, 'template'),
+                            process.cwd());
 
-                            expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
-                            expect(spawn.calls[1].arguments[2].cwd).toEqual(process.cwd());
+                        expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                        expect(spawn.calls[1].arguments[2].cwd).toEqual(process.cwd());
 
-                            expect(log.calls[0].arguments[0]).toInclude('Installing template setup dependencies');
-                            expect(log.calls[1].arguments[0]).toInclude('Installing template dependencies');
-                            expect(log.calls[2].arguments[0]).toInclude('Setup completed');
-                        });
+                        expect(log.calls[0].arguments[0]).toInclude('Installing template setup dependencies');
+                        expect(log.calls[1].arguments[0]).toInclude('Installing template dependencies');
+                        expect(log.calls[2].arguments[0]).toInclude('Setup completed');
+                    });
                 });
             });
         });

--- a/test/documentation/data/documentation-object.js
+++ b/test/documentation/data/documentation-object.js
@@ -22,7 +22,8 @@ export const validDocumentObject = [{
         type: 'String',
         validator: isString
     }],
-    children: []
+    children: [],
+    parentNames: []
 }, {
     name: 'dev',
     level: 0,
@@ -37,7 +38,8 @@ export const validDocumentObject = [{
         type: 'String',
         validator: required(isString)
     }],
-    children: []
+    children: [],
+    parentNames: []
 }];
 
 export const complexDocumentObject = [{

--- a/test/documentation/generate-table.js
+++ b/test/documentation/generate-table.js
@@ -20,7 +20,7 @@ describe('roc', () => {
                         name: 'Path'
                     },
                     cli: {
-                        name: 'CLI Flag'
+                        name: 'CLI Option'
                     },
                     defaultValue: {
                         name: 'Default'
@@ -45,13 +45,13 @@ describe('roc', () => {
                             runtime
                             Runtime configuration
 
-                            | Name    | Description  | Path            | CLI Flag      | Default | Type   | Required |
+                            | Name    | Description  | Path            | CLI Option    | Default | Type   | Required |
                             | ------- | ------------ | --------------- | ------------- | ------- | ------ | -------- |
                             | option1 | description1 | runtime.option1 | --option1     | value1  | String | No       |
 
                             dev
 
-                            | Name    | Description  | Path            | CLI Flag      | Default | Type   | Required |
+                            | Name    | Description  | Path            | CLI Option    | Default | Type   | Required |
                             | ------- | ------------ | --------------- | ------------- | ------- | ------ | -------- |
                             | option2 | description2 | dev.option2     | --dev-option2 |         | String | Yes      |
                             `

--- a/test/documentation/helpers.js
+++ b/test/documentation/helpers.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import {
     pad,
     addPadding,
-    toCliFlag,
+    toCliOption,
     getDefaultValue
 } from '../../src/documentation/helpers';
 
@@ -22,13 +22,13 @@ describe('roc', () => {
                 });
             });
 
-            describe('toCliFlag', () => {
+            describe('toCliOption', () => {
                 it('should return a runtime option correct', () => {
-                    expect(toCliFlag(['runtime', 'option1'])).toBe('--option1');
+                    expect(toCliOption(['runtime', 'option1'])).toBe('--option1');
                 });
 
                 it('should return a "general" option correct', () => {
-                    expect(toCliFlag(['build', 'option2'])).toBe('--build-option2');
+                    expect(toCliOption(['build', 'option2'])).toBe('--build-option2');
                 });
             });
 

--- a/test/documentation/index.js
+++ b/test/documentation/index.js
@@ -32,10 +32,10 @@ describe('roc', () => {
                     redent(`
                         # Runtime
 
-                        | Name    | Description | Path            | CLI Flag  | Default | Type      | Required |
-                        | ------- | ----------- | --------------- | --------- | ------- | --------- | -------- |
-                        | port    |             | runtime.port    | --port    | \`80\`    | \`Unknown\` | No       |
-                        | enabled |             | runtime.enabled | --enabled | \`false\` | \`Unknown\` | No       |
+                        | Name    | Description | Path            | CLI option | Default | Type      | Required |
+                        | ------- | ----------- | --------------- | ---------- | ------- | --------- | -------- |
+                        | enabled |             | runtime.enabled | --enabled  | \`false\` | \`Unknown\` | No       |
+                        | port    |             | runtime.port    | --port     | \`80\`    | \`Unknown\` | No       |
                         `
                     )
                 );
@@ -75,10 +75,10 @@ describe('roc', () => {
                     redent(`
                         runtime
 
-                        | Description                                                                                           | Path         | Default | CLI Flag | Required |
-                        | ----------------------------------------------------------------------------------------------------- | ------------ | ------- | -------- | -------- |
-                        | Some really long description string that is over 100 characters long so we can test the cut off and … | runtime.port | 80      | --port   | No       |
-                        | Short description                                                                                     | runtime.on   | false   | --on     | No       |
+                        | Description                                                                                           | Path         | Default | CLI option | Required |
+                        | ----------------------------------------------------------------------------------------------------- | ------------ | ------- | ---------- | -------- |
+                        | Short description                                                                                     | runtime.on   | false   | --on       | No       |
+                        | Some really long description string that is over 100 characters long so we can test the cut off and … | runtime.port | 80      | --port     | No       |
                         `
                     )
                 );


### PR DESCRIPTION
- Adds the possibility to add general options to commands
  - Will use it to enable extra control over roc init initially
  - Also fixed some issues in the output from the cli
  - Added parentNames to the groupTitleWrapper function in table settings
  - Added the entire row object to the cell renderer
  - Some more tests to verify functionality
- Added a way to list available versions and force install template

This PR renames `options` => `arguments`.
