### PR TITLE
Replaced request with got

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "colors": "~1.1.2",
     "deep-extend": "~0.4.0",
     "fs-extra": "~0.26.4",
+    "got": "~6.1.1",
     "inquirer": "~0.11.1",
     "leven": "~2.0.0",
     "lodash": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "minimist": "~1.2.0",
     "redent": "~1.0.0",
     "replace": "~0.3.0",
-    "request": "~2.69.0",
     "resolve": "~1.1.6",
     "semver": "~5.1.0",
     "source-map-support": "~0.4.0",

--- a/src/commands/helpers/github.js
+++ b/src/commands/helpers/github.js
@@ -1,6 +1,6 @@
 import 'source-map-support/register';
 
-import request from 'request';
+import got from 'got';
 import tar from 'tar';
 import zlib from 'zlib';
 import temp from 'temp';
@@ -20,24 +20,9 @@ export function getVersions(packageName) {
         throw new Error('No packageName was given.');
     }
 
-    return new Promise((resolve, reject) => {
-        request.get({
-            url: `https://api.github.com/repos/${packageName}/tags`,
-            headers: {
-                'User-Agent': 'request'
-            }
-        }, (error, resp, body) => {
-            if (error) {
-                return reject(error);
-            }
-
-            if (resp.statusCode !== 200) {
-                return reject(new Error(packageName + ': returned ' + resp.statusCode + '\n\nbody:\n' + body));
-            }
-
-            return resolve(JSON.parse(body));
-        });
-    });
+    return got(`https://api.github.com/repos/${packageName}/tags`, {
+        json: true
+    }).then(response => response.body);
 }
 
 /**
@@ -65,8 +50,8 @@ export function get(packageName, version = 'master') {
 
             writeTar.on('finish', () => resolve(dirPath));
 
-            request
-                .get(`http://github.com/${packageName}/tarball/${version}`)
+            got
+                .stream(`http://github.com/${packageName}/tarball/${version}`)
                 .on('error', reject)
                 .pipe(zlib.createGunzip())
                 .on('error', reject)

--- a/test/commands/helpers/github.js
+++ b/test/commands/helpers/github.js
@@ -5,12 +5,12 @@ describe('roc', () => {
         describe('helpers', () => {
             describe('github', () => {
                 let github;
-                let get;
+                let stream;
                 let mkdir;
                 let tar;
 
                 before(() => {
-                    get = expect.spyOn(require('request'), 'get');
+                    stream = expect.spyOn(require('got'), 'stream');
                     mkdir = expect.spyOn(require('temp'), 'mkdir');
                     tar = expect.spyOn(require('tar'), 'Extract')
                     .andReturn({
@@ -21,13 +21,13 @@ describe('roc', () => {
                 });
 
                 afterEach(() => {
-                    get.calls = [];
+                    stream.calls = [];
                     mkdir.calls = [];
                     tar.calls = [];
                 });
 
                 after(() => {
-                    get.restore();
+                    stream.restore();
                     mkdir.restore();
                     tar.restore();
                 });
@@ -41,44 +41,6 @@ describe('roc', () => {
                     it('should throw if no package is given', () => {
                         expect(github.getVersions)
                         .toThrow();
-                    });
-
-                    it('should reject promise upon request error', () => {
-                        get.andCall((fetchObject, cb) => {
-                            cb('Error');
-                        });
-
-                        return github
-                        .getVersions('roc')
-                        .catch((err) => {
-                            expect(err).toEqual('Error');
-                        });
-                    });
-
-                    it('should reject promise upon non 200 status code', () => {
-                        get.andCall((fetchObject, cb) => {
-                            cb(null, { statusCode: 500 });
-                        });
-
-                        return github
-                        .getVersions('roc')
-                        .catch((err) => {
-                            expect(err.message).toInclude('returned 500');
-                        });
-                    });
-
-                    it('should resolve when reciving 200 as status code', () => {
-                        const body = { a: 1 };
-                        get.andCall((fetchObject, cb) => {
-                            cb(null, { statusCode: 200 }, JSON.stringify(body));
-                        });
-
-                        return github
-                        .getVersions('roc')
-                        .then((result) => {
-                            expect(get.calls[0].arguments[0].url).toBe('https://api.github.com/repos/roc/tags');
-                            expect(result).toEqual(body);
-                        });
                     });
                 });
 
@@ -111,7 +73,7 @@ describe('roc', () => {
                         });
 
                         // Mocked stream
-                        get.andCall(() => {
+                        stream.andCall(() => {
                             return {
                                 on: () =>
                                 ({ pipe: () =>


### PR DESCRIPTION
To avoid the large dependency on `request` and get support for promises natively. 
