### PR TITLE
Fixed a problem when a command had a string it

### DIFF
--- a/src/cli/execute.js
+++ b/src/cli/execute.js
@@ -32,7 +32,7 @@ function runCommand(syncCommands, path = process.cwd()) {
     const command = syncCommands.shift();
 
     if (command) {
-        const parts = command.split(/\s+/g);
+        const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g);
         const cmd = parts[0];
         const args = parts.slice(1);
 
@@ -84,7 +84,7 @@ function runCommandSync(syncCommands, path = process.cwd()) {
     const command = syncCommands.shift();
 
     if (command) {
-        const parts = command.split(/\s+/g);
+        const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g);
         const cmd = parts[0];
         const args = parts.slice(1);
 


### PR DESCRIPTION
There was a problem when a command had a string in it where the command would be interpreted incorrectly.

For example would this command `git commit -m "Version 1.0.0"` fail since it would split on space ignoring `"`. This PR will solve the issue.
