### PR TITLE
Fixed a small problem with execute and made it a bit more flexible

### DIFF
--- a/src/cli/execute.js
+++ b/src/cli/execute.js
@@ -32,7 +32,7 @@ function runCommand(syncCommands, path = process.cwd()) {
     const command = syncCommands.shift();
 
     if (command) {
-        const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g);
+        const parts = getParts(command);
         const cmd = parts[0];
         const args = parts.slice(1);
 
@@ -84,7 +84,7 @@ function runCommandSync(syncCommands, path = process.cwd()) {
     const command = syncCommands.shift();
 
     if (command) {
-        const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g);
+        const parts = getParts(command);
         const cmd = parts[0];
         const args = parts.slice(1);
 
@@ -101,4 +101,25 @@ function runCommandSync(syncCommands, path = process.cwd()) {
 
         return runCommandSync(syncCommands, path);
     }
+}
+
+/**
+ * Will take a command string an return an array with the different parts of the command.
+ *
+ * Will manage command parts that has been grouped with " or '.
+ *
+ * @param {string} commandString - The string to split up into parts.
+ *
+ * @returns {string[]} - An array with the different parts of the command.
+ */
+function getParts(commandString) {
+    const regex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
+    const parts = [];
+    let match;
+
+    while ((match = regex.exec(commandString))) {
+        parts.push(match[1] || match[2] || match[0]);
+    }
+
+    return parts;
 }

--- a/src/cli/execute.js
+++ b/src/cli/execute.js
@@ -118,7 +118,8 @@ function getParts(commandString) {
     let match;
 
     while ((match = regex.exec(commandString))) {
-        parts.push(match[1] || match[2] || match[0]);
+        const [generalMatch, doubleQuotationMatch, singleQuotationMatch] = match;
+        parts.push(doubleQuotationMatch || singleQuotationMatch || generalMatch);
     }
 
     return parts;

--- a/test/cli/execute.js
+++ b/test/cli/execute.js
@@ -78,6 +78,14 @@ describe('execute', () => {
             });
         });
 
+        it('should manage strings in commands', () => {
+            return execute('git commit -m "Version 1.0.0" -a\'Something else important\'').then(() => {
+                expect(spawn.calls.length).toEqual(1);
+                expect(spawn.calls[0].arguments.slice(0, 2))
+                    .toEqual(['git', ['commit', '-m', 'Version 1.0.0', '-a', 'Something else important']]);
+            });
+        });
+
         it('should handle sync commands correctly and run in the correct order', () => {
             return execute('npm view roc && roc -h & git log').then(() => {
                 expect(spawn.calls[0].arguments.slice(0, 1)).toEqual(['npm']);


### PR DESCRIPTION
This fixes a problem introduced in #69 and makes it a bit better, now supporting both `"` and `'`.
