### PR TITLE
Added default value for args in runHookDirectly

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -89,7 +89,7 @@ export function runHookDirectly({
         returns,
         arguments: argumentsDefinitions,
         initialValue
-    }, args, callback) {
+    }, args = [], callback) {
     // Validate args
     if (argumentsDefinitions) {
         args.forEach((arg, i) => {


### PR DESCRIPTION
This to not require this to be called with an empty array
