### PR TITLE
Better support for regexp

### DIFF
--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { isPlainObject, isBoolean, isString, set, difference, isFunction } from 'lodash';
+import { isPlainObject, isBoolean, isString, set, difference, isFunction, isRegExp } from 'lodash';
 import resolve from 'resolve';
 import trimNewlines from 'trim-newlines';
 import redent from 'redent';
@@ -13,7 +13,7 @@ import { fileExists, getRocPackageDependencies, getRocPluginDependencies, getPac
 import onProperty from '../helpers/on-property';
 import { isValid, throwError } from '../validation';
 import { warning, infoLabel, errorLabel, warningLabel, feedbackMessage } from '../helpers/style';
-import { toArray } from '../converters';
+import { toArray, toRegExp } from '../converters';
 import { registerHooks } from '../hooks';
 import { registerActions, registerAction } from '../hooks/actions';
 import getSuggestions from '../helpers/get-suggestions';
@@ -588,6 +588,8 @@ function getConverter(value, name) {
 
             return value;
         };
+    } else if (isRegExp(value)) {
+        return (input) => toRegExp(input);
     } else if (Array.isArray(value)) {
         return toArray;
     } else if (Number.isInteger(value)) {

--- a/src/converters/index.js
+++ b/src/converters/index.js
@@ -1,2 +1,2 @@
 export toArray from './to-array';
-export toRegexp from './to-regexp';
+export toRegExp from './to-regexp';

--- a/src/converters/index.js
+++ b/src/converters/index.js
@@ -1,1 +1,2 @@
 export toArray from './to-array';
+export toRegexp from './to-regexp';

--- a/src/converters/to-regexp.js
+++ b/src/converters/to-regexp.js
@@ -1,0 +1,19 @@
+import { isRegExp } from 'lodash';
+
+/**
+ * Given an input the function will return an RegExp.
+ *
+ * @param {object} input - The input to be converted.
+ *
+ * @returns {RegExp} - The converted result.
+ */
+export default function toRegExp(input) {
+    if (isRegExp(input)) {
+        return input;
+    }
+
+    // Remove potential leading / / and get possible flags
+    const parsedInput = /^\/?(.*?)(?:\/?|\/([gimuy]*))$/.exec(input);
+
+    return new RegExp(parsedInput[1], parsedInput[2]);
+}

--- a/src/converters/to-regexp.js
+++ b/src/converters/to-regexp.js
@@ -1,7 +1,7 @@
 import { isRegExp } from 'lodash';
 
 /**
- * Given an input the function will return an RegExp.
+ * Given an input the function will return a RegExp.
  *
  * @param {object} input - The input to be converted.
  *

--- a/src/documentation/helpers.js
+++ b/src/documentation/helpers.js
@@ -1,5 +1,5 @@
 import stripAnsi from 'strip-ansi';
-import { isPlainObject, isString } from 'lodash';
+import { isPlainObject, isString, isRegExp } from 'lodash';
 
 /**
  * Returns a string to pad with.
@@ -53,6 +53,11 @@ export function getDefaultValue(object) {
         isString(object) && !object ||
         isPlainObject(object) && Object.keys(object).length === 0) {
         return null;
+    }
+
+    // Make sure we get something sensible when having a RegExp
+    if (isRegExp(object)) {
+        return object.toString();
     }
 
     return JSON.stringify(object);

--- a/src/validation/validators.js
+++ b/src/validation/validators.js
@@ -3,7 +3,8 @@ import {
   isString as lodashIsString,
   isBoolean as lodashIsBoolean,
   isPlainObject as lodashIsPlainObject,
-  isFunction as lodashIsFunction
+  isFunction as lodashIsFunction,
+  isRegExp as lodashIsRegExp
 } from 'lodash';
 
 import isProm from 'is-promise';
@@ -82,7 +83,7 @@ export function isArrayOrSingle(validator) {
 }
 
 /**
- * Validates an string.
+ * Validates a promise.
  *
  * @param {object} value - Something to validate.
  * @param {boolean} info - If type information should be returned.
@@ -94,7 +95,26 @@ export function isPromise(value, info) {
     }
 
     if (!isProm(value)) {
-        return 'Was not a promise!';
+        return 'Was not a Promise!';
+    }
+
+    return true;
+}
+
+/**
+ * Validates a RegExp.
+ *
+ * @param {object} value - Something to validate.
+ * @param {boolean} info - If type information should be returned.
+ * @return {infoObject|boolean|string} - Type information or if it is valid.
+ */
+export function isRegExp(value, info) {
+    if (info) {
+        return infoObject('RegExp');
+    }
+
+    if (!lodashIsRegExp(value)) {
+        return 'Was not a RegExp!';
     }
 
     return true;

--- a/test/converters/to-regexp.js
+++ b/test/converters/to-regexp.js
@@ -1,0 +1,34 @@
+import expect from 'expect';
+
+import toRegExp from '../../src/converters/to-regexp';
+
+describe('roc', () => {
+    describe('converters', () => {
+        describe('toRegExp', () => {
+            it('should pass the value through if it already is a RegExp', () => {
+                const regexp = /abc/;
+                expect(toRegExp(regexp)).toEqual(regexp);
+            });
+
+            it('should convert a string to regexp, without flags and slashes', () => {
+                expect(toRegExp('abc')).toEqual(/abc/);
+            });
+
+            it('should convert a string to regexp, without flags', () => {
+                expect(toRegExp('/abc/')).toEqual(/abc/);
+            });
+
+            it('should convert a string to regexp', () => {
+                expect(toRegExp('/abc/g')).toEqual(/abc/g);
+            });
+
+            it('should convert a string to regexp that only have a leading slash', () => {
+                expect(toRegExp('/abc')).toEqual(/abc/);
+            });
+
+            it('should convert a string to regexp that only have a trailing slash', () => {
+                expect(toRegExp('abc/')).toEqual(/abc/);
+            });
+        });
+    });
+});

--- a/test/documentation/helpers.js
+++ b/test/documentation/helpers.js
@@ -52,6 +52,11 @@ describe('roc', () => {
                     expect(getDefaultValue({a: [1]}))
                         .toEqual('{"a":[1]}');
                 });
+
+                it('should return RegExp as string', () => {
+                    expect(getDefaultValue(/abc/))
+                        .toEqual('/abc/');
+                });
             });
         });
     });

--- a/test/validation/validators.js
+++ b/test/validation/validators.js
@@ -4,6 +4,7 @@ import {
     isArray,
     isObject,
     isArrayOrSingle,
+    isPromise,
     isRegExp,
     isString,
     isBoolean,
@@ -133,6 +134,26 @@ describe('roc', () => {
                     expect(isArrayOrSingle(spy)([1, 2, 3]))
                         .toBe(false);
                     expect(spy.calls.length).toBe(1);
+                });
+            });
+
+            describe('isPromise', () => {
+                it('should return info object if requested', () => {
+                    expect(isPromise(null, true))
+                        .toEqual({
+                            type: 'Promise',
+                            required: false
+                        });
+                });
+
+                it('should validate a RegExp correctly', () => {
+                    expect(isPromise(Promise.resolve()))
+                        .toBe(true);
+                });
+
+                it('should return error if value is not a RegExp', () => {
+                    expect(isPromise(() => {}))
+                        .toInclude('not a Promise');
                 });
             });
 

--- a/test/validation/validators.js
+++ b/test/validation/validators.js
@@ -4,6 +4,7 @@ import {
     isArray,
     isObject,
     isArrayOrSingle,
+    isRegExp,
     isString,
     isBoolean,
     isInteger,
@@ -132,6 +133,26 @@ describe('roc', () => {
                     expect(isArrayOrSingle(spy)([1, 2, 3]))
                         .toBe(false);
                     expect(spy.calls.length).toBe(1);
+                });
+            });
+
+            describe('isRegExp', () => {
+                it('should return info object if requested', () => {
+                    expect(isRegExp(null, true))
+                        .toEqual({
+                            type: 'RegExp',
+                            required: false
+                        });
+                });
+
+                it('should validate a RegExp correctly', () => {
+                    expect(isRegExp(/abc/))
+                        .toBe(true);
+                });
+
+                it('should return error if value is not a RegExp', () => {
+                    expect(isRegExp('/abc/'))
+                        .toInclude('not a RegExp');
                 });
             });
 

--- a/test/validation/validators.js
+++ b/test/validation/validators.js
@@ -146,12 +146,12 @@ describe('roc', () => {
                         });
                 });
 
-                it('should validate a RegExp correctly', () => {
+                it('should validate a Promise correctly', () => {
                     expect(isPromise(Promise.resolve()))
                         .toBe(true);
                 });
 
-                it('should return error if value is not a RegExp', () => {
+                it('should return error if value is not a Promise', () => {
                     expect(isPromise(() => {}))
                         .toInclude('not a Promise');
                 });


### PR DESCRIPTION
This PR will add support for the following in regards to RegExp:
- Validation function to be used with settings, commands and actions/hooks
- Convertor that can be used with commands and automatically with settings

Some tests for this is also added along with tests that where missing for `isPromise`.
