### PR TITLE
Require Node4+ and npm3+ on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Build modern web applications easily",
   "main": "lib/index.js",
   "bin": "bin/index.js",
+  "engineStrict": true,
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.0.0",
+    "npm": ">=3.0.0"
   },
   "files": [
     "converters",


### PR DESCRIPTION
The npm requirement is hopefully temporary but will make it clearer when installing Roc.
