### PR TITLE
Template as a zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 lib
 esdocs
 coverage
+.idea

--- a/docs/config/commands.md
+++ b/docs/config/commands.md
@@ -29,6 +29,7 @@ A string command is a string that will managed as if it was typed into the termi
 The function will be invoked with an object with the following properties.
 ```
 verbose             If verbose mode has been enabled
+directory           Path to working directory
 info                The object that is passed to the runCli function with version and name
 configObject        The final configuration object where everything has been merged
 metaObject          The final meta configuration object where everything has been merged
@@ -41,6 +42,9 @@ actions             The currently registered actions
 
 ### verbose
 Debug will be set to `true` if `-V, --verbose` was set. Should be used to print extra information when running the command. Otherwise it will be `false`.
+
+### directory
+If set it will be used as the current working directory. The path can be either relative to the current working directory or absolute.
 
 ### info
 The same information object as `runCli` was invoked with, meaning it should have two properties.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "tar": "~2.2.1",
     "temp": "~0.8.3",
     "trim-newlines": "~1.0.0",
+    "unzip": "^0.1.11",
     "update-notifier": "0.6.3"
   }
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -124,6 +124,7 @@ export function runCli(info = { version: 'Unknown', name: 'Unknown' }, initalCon
         // Run the command
         return configObject.commands[command]({
             verbose: verboseMode,
+            directory: dirPath,
             info,
             configObject,
             metaObject,

--- a/src/commands/helpers/unzip.js
+++ b/src/commands/helpers/unzip.js
@@ -1,0 +1,47 @@
+import temp from 'temp';
+import fs from 'fs';
+import nodeUnzip from 'unzip';
+import path from 'path';
+
+// Automatically track and cleanup files at exit
+temp.track();
+
+/**
+ * Unpacks the given zip file.
+ *
+ * @param {string} zipFile - The full path to a local zip file.
+ *
+ * @returns {Promise} The path to the temporary directory where the unzipped files are located.
+ */
+export default function unzip(zipFile) {
+    if (!zipFile) {
+        throw new Error('No zip file was given.');
+    }
+
+    return new Promise((resolve, reject) => {
+        temp.mkdir('roc', (err, dirPath) => {
+            if (err) {
+                return reject(err);
+            }
+
+            fs.createReadStream(zipFile)
+                .pipe(nodeUnzip.Extract({ path: dirPath })) // eslint-disable-line new-cap
+                .on('error', reject)
+                .on('close', () => {
+                    // The template zip is assumed to have a root dir
+                    try {
+                        fs.readdirSync(dirPath)
+                            .forEach((file) => {
+                                const rootDir = path.join(dirPath, file);
+                                if (fs.statSync(rootDir).isDirectory()) {
+                                    return resolve(rootDir);
+                                }
+                            });
+                    } catch (error) {
+                        return reject(error);
+                    }
+                    return resolve(dirPath);
+                });
+        });
+    });
+}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -34,7 +34,7 @@ const templates = [{
  */
 export default function init({ parsedArguments, parsedOptions, directory }) {
     const { list, force } = parsedOptions.options;
-    const { template, version } = parsedArguments.arguments;
+    const { name, template, version } = parsedArguments.arguments;
 
     // Get versions first
     if (template && list) {
@@ -44,7 +44,7 @@ export default function init({ parsedArguments, parsedOptions, directory }) {
     }
 
     // Make sure the directory is empty!
-    return checkFolder(force, directory).then((dir) => {
+    return checkFolder(force, name || directory).then((dir) => {
         if (!template) {
             return interactiveMenu(dir, list);
         }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -8,6 +8,7 @@ import chalk from 'chalk';
 import { get, getVersions } from './helpers/github';
 import { validRocProject } from './helpers/general';
 import { error, warning, info, ok } from '../helpers/style';
+import { getAbsolutePath } from '../helpers';
 import unzip from './helpers/unzip';
 
 /* This should be fetched from a server!
@@ -260,9 +261,7 @@ function interactiveMenu(directory, list) {
 
 function checkFolder(force = false, directory = '') {
     return new Promise((resolve) => {
-        const directoryPath = directory.indexOf('/') === 0 ?
-            directory :
-            path.join(process.cwd(), directory);
+        const directoryPath = getAbsolutePath(directory || process.cwd());
         fs.mkdir(directoryPath, (err) => {
             if (err) {
                 console.log(
@@ -291,7 +290,7 @@ function checkFolder(force = false, directory = '') {
                         process.exit(1);
                         /* eslint-enable */
                     } else if (selection === 'new') {
-                        askForDirectory(resolve);
+                        askForDirectory(directory, resolve);
                     } else if (selection === 'force') {
                         resolve(directoryPath);
                     }
@@ -303,13 +302,13 @@ function checkFolder(force = false, directory = '') {
     });
 }
 
-function askForDirectory(resolve) {
+function askForDirectory(directory, resolve) {
     inquirer.prompt([{
         type: 'input',
         name: 'name',
         message: 'What do you want to name the directory?'
     }], ({ name }) => {
-        const directoryPath = name.indexOf('/') === 0 ? name : path.join(process.cwd(), name);
+        const directoryPath = getAbsolutePath(name, directory);
         fs.mkdir(directoryPath, (err) => {
             if (err) {
                 console.log(warning('The directory did already exists or was not empty.'), '\n');

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -44,7 +44,7 @@ export default function init({ parsedArguments, parsedOptions, directory }) {
     }
 
     // Make sure the directory is empty!
-    return checkFolder(force, name || directory).then((dir) => {
+    return checkFolder(force, name, directory).then((dir) => {
         if (!template) {
             return interactiveMenu(dir, list);
         }
@@ -259,9 +259,9 @@ function interactiveMenu(directory, list) {
     });
 }
 
-function checkFolder(force = false, directory = '') {
+function checkFolder(force = false, directoryName = '', directory = '') {
     return new Promise((resolve) => {
-        const directoryPath = getAbsolutePath(directory || process.cwd());
+        const directoryPath = getAbsolutePath(path.join(directory, directoryName));
         fs.mkdir(directoryPath, (err) => {
             if (err) {
                 console.log(
@@ -306,7 +306,7 @@ function askForDirectory(directory, resolve) {
     inquirer.prompt([{
         type: 'input',
         name: 'name',
-        message: `What do you want to name the directory? (It will be created in '${directory || process.cwd()}')`,
+        message: `What do you want to name the directory? (It will be created in '${directory || process.cwd()}')`
     }], ({ name }) => {
         const directoryPath = getAbsolutePath(name, directory);
         fs.mkdir(directoryPath, (err) => {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -306,7 +306,7 @@ function askForDirectory(directory, resolve) {
     inquirer.prompt([{
         type: 'input',
         name: 'name',
-        message: 'What do you want to name the directory?'
+        message: `What do you want to name the directory? (It will be created in '${directory || process.cwd()}')`,
     }], ({ name }) => {
         const directoryPath = getAbsolutePath(name, directory);
         fs.mkdir(directoryPath, (err) => {

--- a/src/roc/index.js
+++ b/src/roc/index.js
@@ -20,7 +20,7 @@ const initOptions = [{
 const initArguments = [{
     name: 'template',
     validation: isPath,
-    description: 'The template to use. Matches Github structure with Username/Repo.'
+    description: 'The template to use. Matches Github structure with Username/Repo or a local zip file.'
 }, {
     name: 'version',
     validation: isString,
@@ -63,6 +63,8 @@ const roc = {
 
                     __template__
                     Template can either be a short name for a specific template, currently it accepts \`web-app\` and \`web-app-react\` that will be converted internally to \`rocjs/roc-template-web-app\` and \`rocjs/roc-template-web-app-react\`. As can be seen here the actual template reference is a Github repo and can be anything matching that pattern \`USERNAME/PROJECT\`.
+
+                    The template can also point to a local zip file (ending in \`.zip\`) of a template repository. This is useful if the template is on a private repo or not on GitHub.
 
                     It will also expect that the template has a folder named \`template\` and that inside of it there is \`package.json\` file with at least one dependency to a Roc module following the pattern \`roc-package-*\` or that it has a \`roc.config.js\` file (this file is then expected to have some [packages](/docs/config/packages.md) defined but this is not checked immediately).
 

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -80,6 +80,7 @@ describe('roc', () => {
 
                     expect(spy.calls[0].arguments[0]).toEqual({
                         verbose: false,
+                        directory: undefined,
                         info: info,
                         configObject: config,
                         packageConfig: config,
@@ -100,6 +101,7 @@ describe('roc', () => {
 
                     expect(spy.calls[0].arguments[0]).toEqual({
                         verbose: true,
+                        directory: undefined,
                         info: info,
                         configObject: config,
                         packageConfig: config,
@@ -130,6 +132,7 @@ describe('roc', () => {
 
                     expect(spy.calls[0].arguments[0]).toEqual({
                         verbose: false,
+                        directory: undefined,
                         info: info,
                         configObject: newConfig,
                         packageConfig: config,

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -69,6 +69,19 @@ describe('roc', () => {
             after(() => {
             });
 
+            function setupMocks({ versions = [{ name: 'v1.0' }] } = {}) {
+                const dirPath = path.join(__dirname, 'data', 'valid-template');
+
+                prompt.andCall((options, cb) => {
+                    cb({option: 'web'});
+                });
+                readdirSync.andReturn([]);
+                getVersions.andReturn(Promise.resolve(versions));
+                get.andReturn(Promise.resolve(dirPath));
+
+                return dirPath;
+            }
+
             it('should give information about non empty directory and terminate process if selected', () => {
                 readdirSync.andReturn([1]);
 
@@ -133,14 +146,8 @@ describe('roc', () => {
             });
 
             it('should directly fetch template if provided by full name without version given', () => {
-                const dirPath = path.join(__dirname, 'data', 'valid-template');
+                const dirPath = setupMocks({ versions: ['1.0'] });
 
-                prompt.andCall((options, cb) => {
-                    cb({option: 'web'});
-                });
-                readdirSync.andReturn([]);
-                getVersions.andReturn(Promise.resolve(['1.0']));
-                get.andReturn(Promise.resolve(dirPath));
                 return consoleMockWrapper((log) => {
                     return init({
                         parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
@@ -159,6 +166,32 @@ describe('roc', () => {
                         expect(log.calls[1].arguments[0]).toInclude('Installing template dependencies');
                         expect(log.calls[2].arguments[0]).toInclude('Setup completed');
                     });
+                });
+            });
+
+            it('should use directory as install dir', () => {
+                const dirPath = setupMocks();
+
+                return init({
+                    directory: 'roc-directory',
+                    parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
+                    parsedOptions: { options: {} }
+                }).then(() => {
+                    expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                    expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-directory'));
+                });
+            });
+
+            it('should choose name over directory', () => {
+                const dirPath = setupMocks();
+
+                return init({
+                    directory: 'roc-directory',
+                    parsedArguments: { arguments: { template: 'vgno/roc-template-web', name: 'roc-name' } },
+                    parsedOptions: { options: {} }
+                }).then(() => {
+                    expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                    expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-name'));
                 });
             });
 
@@ -203,14 +236,8 @@ describe('roc', () => {
             });
 
             it('should manage the provided template version as expected', () => {
-                const dirPath = path.join(__dirname, 'data', 'valid-template');
+                const dirPath = setupMocks({ versions: [{ name: 'v1.0' }] });
 
-                prompt.andCall((options, cb) => {
-                    cb({option: 'web'});
-                });
-                readdirSync.andReturn([]);
-                getVersions.andReturn(Promise.resolve([{name: 'v1.0'}]));
-                get.andReturn(Promise.resolve(path.join(__dirname, 'data', 'valid-template')));
                 return consoleMockWrapper((log) => {
                     return init({
                         parsedArguments: { arguments:

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -110,7 +110,8 @@ describe('roc', () => {
                     return init({ parsedArguments: { arguments: {} }, parsedOptions: { options: {} } })
                         .catch(() => {
                             expect(prompt.calls[1].arguments[0][0].message)
-                                .toBe(`What do you want to name the directory? (It will be created in '${process.cwd()}')`);
+                                .toBe('What do you want to name the directory? ' +
+                                    `(It will be created in '${process.cwd()}')`);
                         });
                 });
             });
@@ -194,7 +195,8 @@ describe('roc', () => {
                         parsedOptions: { options: {} }
                     }).then(() => {
                         expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
-                        expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-name'));
+                        expect(spawn.calls[1].arguments[2].cwd)
+                            .toEqual(path.join(process.cwd(), 'roc-directory', 'roc-name'));
                     });
                 });
             });

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -172,26 +172,30 @@ describe('roc', () => {
             it('should use directory as install dir', () => {
                 const dirPath = setupMocks();
 
-                return init({
-                    directory: 'roc-directory',
-                    parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
-                    parsedOptions: { options: {} }
-                }).then(() => {
-                    expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
-                    expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-directory'));
+                return consoleMockWrapper(() => {
+                    return init({
+                        directory: 'roc-directory',
+                        parsedArguments: { arguments: { template: 'vgno/roc-template-web' } },
+                        parsedOptions: { options: {} }
+                    }).then(() => {
+                        expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                        expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-directory'));
+                    });
                 });
             });
 
             it('should choose name over directory', () => {
                 const dirPath = setupMocks();
 
-                return init({
-                    directory: 'roc-directory',
-                    parsedArguments: { arguments: { template: 'vgno/roc-template-web', name: 'roc-name' } },
-                    parsedOptions: { options: {} }
-                }).then(() => {
-                    expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
-                    expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-name'));
+                return consoleMockWrapper(() => {
+                    return init({
+                        directory: 'roc-directory',
+                        parsedArguments: { arguments: { template: 'vgno/roc-template-web', name: 'roc-name' } },
+                        parsedOptions: { options: {} }
+                    }).then(() => {
+                        expect(spawn.calls[0].arguments[2].cwd).toEqual(dirPath);
+                        expect(spawn.calls[1].arguments[2].cwd).toEqual(path.join(process.cwd(), 'roc-name'));
+                    });
                 });
             });
 

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -110,7 +110,7 @@ describe('roc', () => {
                     return init({ parsedArguments: { arguments: {} }, parsedOptions: { options: {} } })
                         .catch(() => {
                             expect(prompt.calls[1].arguments[0][0].message)
-                                .toBe('What do you want to name the directory?');
+                                .toBe(`What do you want to name the directory? (It will be created in '${process.cwd()}')`);
                         });
                 });
             });

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -80,7 +80,7 @@ describe('roc', () => {
                     return init({ parsedArguments: { arguments: {} }, parsedOptions: { options: {} } })
                         .catch((error) => {
                             expect(prompt.calls[0].arguments[0][0].message)
-                                .toBe('The directory is not empty, what do you want to do?');
+                                .toBe(`The directory '${process.cwd()}' is not empty, what do you want to do?`);
                             expect(error).toBeA(Error);
                         });
                 });


### PR DESCRIPTION
Added support for the template to point to a local zip file (ending in `.zip`) of a template repository. This is useful if the template is on a private repo or not on GitHub.

As a bonus `init` now respects the general `directory` option. Before this change giving the `directory` option affected where roc was looking for configuration files and stuff, but created the project in the current working directory. Now the project is created at the given directory. If the option is not used it should work as before.
