### PR TITLE
Warning for new core + command to lock down dependencies

### DIFF
--- a/docs/default/Commands.md
+++ b/docs/default/Commands.md
@@ -15,12 +15,23 @@ All commands can be called with some additional options illustrated in the table
 | -v, --version         | Output version number.                         | No       |
 
 ## Commands
+* [lock](#lock)
 * [create](#create)
     * [init](#init)
     * [new](#new)
 * [meta](#meta)
     * [docs](#docs)
     * [list-settings](#list-settings)
+
+## lock
+__Locks down Roc dependencies to fixed alpha versions.__
+
+```
+roc lock
+```
+
+###  Defined by extensions
+roc
 
 ## create
 __Project creation__

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -32,6 +32,10 @@ const initArguments = {
 };
 
 export default {
+    lock: {
+        command: lazyRequire('./lock'),
+        description: 'Locks down Roc dependencies to fixed alpha versions.',
+    },
     create: {
         __meta: {
             name: 'Project creation',

--- a/src/commands/lock.js
+++ b/src/commands/lock.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import { join } from 'path';
+
+import log from '../log/default/small';
+import getAlphaExtensionsThatAreNotLocked, { officialExtensions }
+    from '../context/dependencies/getAlphaExtensionsThatAreNotLocked';
+
+export default function freeze({ context: { packageJSON, directory } }) {
+    const toUpdate = getAlphaExtensionsThatAreNotLocked(packageJSON);
+
+    if (toUpdate) {
+        const newPackageJSON = { ...packageJSON };
+
+        toUpdate.dependencies.forEach((dependency) => {
+            console.log(dependency);
+            newPackageJSON.dependencies[dependency] = officialExtensions[dependency];
+        });
+
+        toUpdate.devDependencies.forEach((dependency) => {
+            console.log(dependency);
+            newPackageJSON.devDependencies[dependency] = officialExtensions[dependency];
+        });
+
+        fs.writeFileSync(join(directory, 'package.json'), JSON.stringify(newPackageJSON, null, 2) + '\n');
+
+        log.success('Locked Roc dependencies in package.json');
+        log.log('  Remove node_modules and run npm install again to complete the process.');
+    } else {
+        log.info('Seems like you already have locked the versions.');
+    }
+}

--- a/src/context/dependencies/getAlphaExtensionsThatAreNotLocked.js
+++ b/src/context/dependencies/getAlphaExtensionsThatAreNotLocked.js
@@ -1,0 +1,78 @@
+export const officialExtensions = {
+    'roc-package-base': '1.0.0-alpha.10',
+    'roc-package-base-dev': '1.0.0-alpha.10',
+
+    'roc-package-module': '1.0.0-alpha.6',
+    'roc-package-module-dev': '1.0.0-alpha.6',
+
+    'roc-package-webpack': '1.0.0-alpha.11',
+    'roc-package-webpack-dev': '1.0.0-alpha.11',
+
+    'roc-package-webpack-web': '1.0.0-alpha.7',
+    'roc-package-webpack-web-dev': '1.0.0-alpha.7',
+
+    'roc-package-webpack-node': '1.0.0-alpha.5',
+    'roc-package-webpack-node-dev': '1.0.0-alpha.5',
+
+    'roc-package-web-app': '1.0.0-alpha.8',
+    'roc-package-web-app-dev': '1.0.0-alpha.8',
+
+    'roc-package-web-app-react': '1.0.0-alpha.11',
+    'roc-package-web-app-react-dev': '1.0.0-alpha.11',
+
+    'roc-plugin-react': '1.0.0-alpha.3',
+    'roc-plugin-react-dev': '1.0.0-alpha.3',
+
+    'roc-plugin-assets-images': '1.0.0-alpha.2',
+
+    'roc-plugin-browsersync': '1.0.0-alpha.3',
+
+    'roc-plugin-start': '1.0.0-alpha.2',
+
+    'roc-plugin-style-css': '1.0.0-alpha.6',
+
+    'roc-plugin-style-sass': '1.0.0-alpha.3',
+
+    'roc-plugin-style-less': '1.0.0-alpha.2',
+
+    'roc-abstract-plugin-test': '1.0.0-alpha.2',
+
+    'roc-plugin-test-mocha-karma-webpack': '1.0.0-alpha.7',
+
+    'roc-plugin-test-mocha-webpack': '1.0.0-alpha.2',
+};
+
+export default function getAlphaExtensionsThatAreNotLocked(packageJSON = {}) {
+    const notLocked = {
+        dependencies: [],
+        devDependencies: [],
+    };
+
+    if (packageJSON.dependencies) {
+        Object.keys(packageJSON.dependencies).forEach((dependency) => {
+            if (
+                /alpha/.test(packageJSON.dependencies[dependency]) &&
+                officialExtensions[dependency] !== packageJSON.dependencies[dependency]
+            ) {
+                notLocked.dependencies.push(dependency);
+            }
+        });
+    }
+
+    if (packageJSON.devDependencies) {
+        Object.keys(packageJSON.devDependencies).forEach((dependency) => {
+            if (
+                /alpha/.test(packageJSON.devDependencies[dependency]) &&
+                officialExtensions[dependency] !== packageJSON.devDependencies[dependency]
+            ) {
+                notLocked.devDependencies.push(dependency);
+            }
+        });
+    }
+
+    if (!notLocked.dependencies.length && !notLocked.devDependencies.length) {
+        return undefined;
+    }
+
+    return notLocked;
+}

--- a/src/context/dependencies/getAlphaExtensionsThatAreNotLocked.js
+++ b/src/context/dependencies/getAlphaExtensionsThatAreNotLocked.js
@@ -20,6 +20,9 @@ export const officialExtensions = {
     'roc-package-web-app-react': '1.0.0-alpha.11',
     'roc-package-web-app-react-dev': '1.0.0-alpha.11',
 
+    'roc-package-web-component': '1.0.0-alpha.4',
+    'roc-package-web-component-dev': '1.0.0-alpha.4',
+
     'roc-plugin-react': '1.0.0-alpha.3',
     'roc-plugin-react-dev': '1.0.0-alpha.3',
 

--- a/src/context/initContext.js
+++ b/src/context/initContext.js
@@ -1,4 +1,5 @@
 import { isFunction, omit } from 'lodash';
+import { yellow, bold } from 'chalk';
 
 import { registerActions } from '../hooks/manageActions';
 import { setResolveRequest, getResolveRequest } from '../require/manageResolveRequest';
@@ -18,6 +19,7 @@ import processRocObject, { handleResult } from './extensions/helpers/processRocO
 import verifyConfigurationStructure from './helpers/verifyConfigurationStructure';
 import verifyInstalledProjectDependencies from './dependencies/verifyInstalledProjectDependencies';
 import verifyRequiredDependencies from './dependencies/verifyRequiredDependencies';
+import getAlphaExtensionsThatAreNotLocked from './dependencies/getAlphaExtensionsThatAreNotLocked';
 
 /**
  * Builds the context.
@@ -148,6 +150,37 @@ export default function initContext({
                         true
                     );
             }
+        }
+
+        /**
+            Temporary warning to manage projects using rc.10
+            and extensions with alpha version
+        */
+        if (getAlphaExtensionsThatAreNotLocked(context.packageJSON)) {
+            console.log(`
+${yellow('================================================ IMPORTANT ================================================')}
+  Roc is getting closer to the first stable 1.0 release and some things have have changed.
+
+  You might be seeing some some warning now about "configuration mismatches" among other things.
+  Most of these warning are easy to address and for the full changes please take a look at the
+  link below. It also contains information about how to update the project to the latest version.
+
+  https://gist.github.com/dlmr/4a548f85b57c1291d63191aecd30caf6
+
+  To remove this warning please update your Roc dependencies to point to at least "beta.1",
+  and preferably lock the versions since we might do more changes in the future that can be breaking.
+
+  If you do not feel like doing this right now you can run the ${bold('"roc lock"')} command that will lock
+  the project dependencies to work as before. If you use this we do encourage you to update
+  eventually to get all the new improvements.
+
+  We promise to keep breaking changes to a minimum and we are really close to release
+  everything as stable.
+
+  If something does not work as expected anymore do not hesitate to post an issue at
+  https://github.com/rocjs/roc
+${yellow('===========================================================================================================')}
+`);
         }
     }
 

--- a/test/documentation/fixtures/projects/complex/docs/Commands.md
+++ b/test/documentation/fixtures/projects/complex/docs/Commands.md
@@ -15,12 +15,23 @@ All commands can be called with some additional options illustrated in the table
 | -v, --version         | Output version number.                         | No       |
 
 ## Commands
+* [lock](#lock)
 * [create](#create)
     * [init](#init)
     * [new](#new)
 * [meta](#meta)
     * [docs](#docs)
     * [list-settings](#list-settings)
+
+## lock
+__Locks down Roc dependencies to fixed alpha versions.__
+
+```
+roc lock
+```
+
+###  Defined by extensions
+roc
 
 ## create
 __Project creation__

--- a/test/documentation/fixtures/projects/empty/docs/Commands.md
+++ b/test/documentation/fixtures/projects/empty/docs/Commands.md
@@ -15,12 +15,23 @@ All commands can be called with some additional options illustrated in the table
 | -v, --version         | Output version number.                         | No       |
 
 ## Commands
+* [lock](#lock)
 * [create](#create)
     * [init](#init)
     * [new](#new)
 * [meta](#meta)
     * [docs](#docs)
     * [list-settings](#list-settings)
+
+## lock
+__Locks down Roc dependencies to fixed alpha versions.__
+
+```
+roc lock
+```
+
+###  Defined by extensions
+roc
 
 ## create
 __Project creation__


### PR DESCRIPTION
Adds a warning if Roc is running with the new core in an "old" project along with a command that locks down the dependencies if the user want to delay the upgrade.
