### PR TITLE
Only create documentation for commands if we have at least one command

### DIFF
--- a/src/documentation/markdown/commandsToMarkdown.js
+++ b/src/documentation/markdown/commandsToMarkdown.js
@@ -63,7 +63,7 @@ export default function commandsToMarkdown(
 
     rows.push(`# Commands for \`${name}\``, '');
 
-    if (commands) {
+    if (commands && Object.keys(commands).length > 0) {
         rows.push('## General Information');
         rows.push('All commands can be called with some additional options illustrated in the table below.', '');
 


### PR DESCRIPTION
This fixes a problem where we would get ugly documentation for plugins that have no commands.
