### PR TITLE
New fallback for missing dependencies and better extension management

### DIFF
--- a/src/context/extensions/buildExtensionTree.js
+++ b/src/context/extensions/buildExtensionTree.js
@@ -1,5 +1,6 @@
 import getExtensions from './steps/getExtensions';
 import processDevExports from './steps/processDevExports';
+import processNormalExports from './steps/processNormalExports';
 import runPostInits from './steps/runPostInits';
 
 const log = require('debug')('roc:core:extensionBuilder');
@@ -19,6 +20,7 @@ export default function buildExtensionTree(context, packages, plugins, checkRequ
         getExtensions('package')(packages),
         getExtensions('plugin')(plugins),
         processDevExports,
+        processNormalExports,
         runPostInits,
         completed,
     ].reduce(
@@ -34,6 +36,7 @@ export default function buildExtensionTree(context, packages, plugins, checkRequ
             temp: {
                 postInits: [],
                 extensionsDevelopmentExports: {},
+                extensionsNormalExports: {},
                 startTime: process.hrtime(),
             },
 

--- a/src/context/extensions/helpers/processRocObject.js
+++ b/src/context/extensions/helpers/processRocObject.js
@@ -72,6 +72,11 @@ export default function processRocObject(
                 state.temp.extensionsDevelopmentExports[roc.name] =
                     state.context.dependencies.exports;
             }
+
+            if (!/^.*-dev$/.test(roc.name)) {
+                state.temp.extensionsNormalExports[roc.name] =
+                    state.context.dependencies.exports;
+            }
         }
 
         // Get possible hooks

--- a/src/context/extensions/steps/processNormalExports.js
+++ b/src/context/extensions/steps/processNormalExports.js
@@ -1,0 +1,39 @@
+import { initSetDependencies } from '../../../require/manageDependencies';
+
+/*
+ We want to make all of the dependencies that the "normal" one has available to the development one
+ since the development one might use some of the "normal" dependencies when running.
+ An example of this is where a development extension includes some code that has a dependency on something that is
+ provided from the "normal" extension. This could be code that wraps a dependency as an example.
+*/
+export default function processNormalExports(initialState) {
+    let dependencyContext = { ...initialState.dependencyContext };
+    initialState.context.usedExtensions.forEach(({ name, packageJSON }) => {
+        // If the name ends in -dev we will remove the -dev part and use that to find dependencies
+        const normalName = /-dev$/.test(name) && name.slice(0, -4);
+        if (normalName && initialState.temp.extensionsNormalExports[normalName]) {
+            dependencyContext =
+                initSetDependencies(dependencyContext)(
+                    name,
+                    {
+                        ...dependencyContext.extensionsDependencies[name],
+                        exports: {
+                            // We add the "normal" exports first since we do not want to overwrite something
+                            // that comes from the development ones because that could result in different
+                            // dependencies in development and production
+                            ...initialState.temp.extensionsNormalExports[normalName],
+                            ...dependencyContext.extensionsDependencies[name].exports,
+                        },
+                    },
+                    // Remove things that are defined in the package.json directly
+                    // This will avoid that different dependencies are used in development and production
+                    packageJSON
+                );
+        }
+    });
+
+    return {
+        ...initialState,
+        dependencyContext,
+    };
+}


### PR DESCRIPTION
The new fallback manages the case when using a unflatten `node_modules` structure where otherwise some dependencies would not be found. Also added `processNormalExports` to make Roc work better with unflatten `node_modules` structure.

Both of this cases could happen during local development when using `npm link`, a situation that results in an unflatten `node_modules` structure.
