### PR TITLE
Fixed an issue where additional arguments where not allowed for hooks

### DIFF
--- a/src/hooks/runHookDirectly.js
+++ b/src/hooks/runHookDirectly.js
@@ -35,16 +35,20 @@ export default function runHookDirectly({
     if (argumentsDefinitions) {
         const argumentsDefinitionsArray = objectToArray(argumentsDefinitions);
         args.forEach((value, i) => {
-            const validationResult = isValid(value, argumentsDefinitionsArray[i].validator);
-            if (validationResult !== true) {
-                try {
-                    throwValidationError(argumentsDefinitionsArray[i].name, validationResult, value, 'argument');
-                } catch (err) {
-                    log.large.error(
-                        `An argument was not valid in ${underline(name)} from ${underline(extension)}.` +
-                            `\n\n${err.message}`,
-                        'Hook problem'
-                    );
+            // If we have meta data for this argument, this means that we will allow
+            // for more arguments than we have validation for.
+            if (argumentsDefinitionsArray[i] && argumentsDefinitionsArray[i].validator) {
+                const validationResult = isValid(value, argumentsDefinitionsArray[i].validator);
+                if (validationResult !== true) {
+                    try {
+                        throwValidationError(argumentsDefinitionsArray[i].name, validationResult, value, 'argument');
+                    } catch (err) {
+                        log.large.error(
+                            `An argument was not valid in ${underline(name)} from ${underline(extension)}.` +
+                                `\n\n${err.message}`,
+                            'Hook problem'
+                        );
+                    }
                 }
             }
         });


### PR DESCRIPTION
This change makes it possible to use more arguments then what have been defined in the meta data for a hook, before we would get a reference error.

The question is if this should be something that we should allow or not, define more arguments than what have been defined in the meta data. In general I like the idea that the meta data aids us but does not limit us but one could argue that we should be more strict.

Thoughts?
