### PR TITLE
Fix typos

### DIFF
--- a/docs/default/Commands.md
+++ b/docs/default/Commands.md
@@ -51,14 +51,14 @@ roc create init [template] [version]
 The __init__ command can be used to initiate a new Roc project and currently expects that it is run inside an empty directory. As shown above it takes two optional arguments, template and version. If no template is given a prompt will be displayed with the possible alternatives that exist. Currently these alternatives are coded into Roc and matches `web-app` and `web-app-react`.
 
 __template__
-Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a Github repo and can be anything matching that pattern `USERNAME/PROJECT`.
+Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a GitHub repo and can be anything matching that pattern `USERNAME/PROJECT`.
 
 The template can also point to a local zip file (ending in `.zip`) of a template repository. This is useful if the template is in a private repo or not available on GitHub.
 
 It will also expect that the template has a folder named `template` that contains a `package.json` file with at least one dependency to a Roc package following the pattern `roc-package-*` or that it has a `roc.config.js` file (this file is then expected to have some [packages](/docs/config/packages.md) defined but this is not checked immediately).
 
 __version__
-Versions should match a tag on the Github repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match Github default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
+Versions should match a tag on the GitHub repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match GitHub default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
 
 #### Arguments
 

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -47,19 +47,19 @@ export default {
             /* eslint-disable max-len */
             help: `
                 Used to init new projects using special templates. If no template is given a prompt will ask you for one.
-                The templates are fetched from Github or from a zip file and it's easy to create new ones.`,
+                The templates are fetched from GitHub or from a zip file and it's easy to create new ones.`,
             markdown: `
                 The __init__ command can be used to initiate a new Roc project and currently expects that it is run inside an empty directory. As shown above it takes two optional arguments, template and version. If no template is given a prompt will be displayed with the possible alternatives that exist. Currently these alternatives are coded into Roc and matches \`web-app\` and \`web-app-react\`.
 
                 __template__
-                Template can either be a short name for a specific template, currently it accepts \`web-app\` and \`web-app-react\` that will be converted internally to \`rocjs/roc-template-web-app\` and \`rocjs/roc-template-web-app-react\`. The actual template reference is a Github repo and can be anything matching that pattern \`USERNAME/PROJECT\`.
+                Template can either be a short name for a specific template, currently it accepts \`web-app\` and \`web-app-react\` that will be converted internally to \`rocjs/roc-template-web-app\` and \`rocjs/roc-template-web-app-react\`. The actual template reference is a GitHub repo and can be anything matching that pattern \`USERNAME/PROJECT\`.
 
                 The template can also point to a local zip file (ending in \`.zip\`) of a template repository. This is useful if the template is in a private repo or not available on GitHub.
 
                 It will also expect that the template has a folder named \`template\` that contains a \`package.json\` file with at least one dependency to a Roc package following the pattern \`roc-package-*\` or that it has a \`roc.config.js\` file (this file is then expected to have some [packages](/docs/config/packages.md) defined but this is not checked immediately).
 
                 __version__
-                Versions should match a tag on the Github repo and will default to master if none exists. When providing an input on the command line Roc will automatically add \`v\` in front of versions that starts with a number to match Github default conventions that have version tags that start with \`v\` like \`v1.0.0\`. \`master\` is also always available as an option.`,
+                Versions should match a tag on the GitHub repo and will default to master if none exists. When providing an input on the command line Roc will automatically add \`v\` in front of versions that starts with a number to match GitHub default conventions that have version tags that start with \`v\` like \`v1.0.0\`. \`master\` is also always available as an option.`,
             /* eslint-enable */
             options: initOptions,
             arguments: initArguments,

--- a/src/commands/init/fetchTemplate.js
+++ b/src/commands/init/fetchTemplate.js
@@ -47,8 +47,8 @@ export default function fetchTemplate(template, directory, version, { clone }) {
         return cloneRepo(template, version);
     }
 
-    // Handle Github templates in first class way, for better support of versions
-    if (!clone && isGithub(template)) {
+    // Handle GitHub templates in first class way, for better support of versions
+    if (!clone && isGitHub(template)) {
         return github(template, version);
     }
 
@@ -196,6 +196,6 @@ function cloneRepo(template, version) {
 }
 
 
-export function isGithub(template) {
+export function isGitHub(template) {
     return template.indexOf(':') === -1 && (template.match(/\//g) || []).length === 1;
 }

--- a/src/commands/init/githubHelpers.js
+++ b/src/commands/init/githubHelpers.js
@@ -9,7 +9,7 @@ export function getOfficialTemplates() {
 }
 
 /**
- * Fetches an array of all the tags for a Github repo, used as possible versions for a template.
+ * Fetches an array of all the tags for a GitHub repo, used as possible versions for a template.
  *
  * @param {string} packageName - A package name, expected to match "username/repo"
  *

--- a/src/commands/init/index.js
+++ b/src/commands/init/index.js
@@ -15,7 +15,7 @@ import getPackageJSON from '../../helpers/getPackageJSON';
 import { getVersions, getOfficialTemplates } from './githubHelpers';
 import generateTemplate from './generateTemplate';
 import checkFolder from './checkFolder';
-import fetchTemplate, { isGithub, isLocal } from './fetchTemplate';
+import fetchTemplate, { isGitHub, isLocal } from './fetchTemplate';
 
 export default async function init({
     arguments: { managed: managedArguments },
@@ -34,7 +34,7 @@ export default async function init({
     if (listVersions) {
         if (isLocal(template, directory)) {
             return log.info('You can’t list versions for local templates');
-        } else if (template.indexOf('/') === -1 || isGithub(template)) {
+        } else if (template.indexOf('/') === -1 || isGitHub(template)) {
             try {
                 const templateVersions = await getVersions(template);
 

--- a/src/commands/init/index.js
+++ b/src/commands/init/index.js
@@ -148,7 +148,7 @@ async function showListOfTemplates() {
     const { option } = await inquirer.prompt([{
         type: 'rawlist',
         name: 'option',
-        message: 'Selected a template',
+        message: 'Select a template',
         choices,
     }]);
 

--- a/test/documentation/fixtures/projects/complex/docs/Commands.md
+++ b/test/documentation/fixtures/projects/complex/docs/Commands.md
@@ -51,14 +51,14 @@ roc create init [template] [version]
 The __init__ command can be used to initiate a new Roc project and currently expects that it is run inside an empty directory. As shown above it takes two optional arguments, template and version. If no template is given a prompt will be displayed with the possible alternatives that exist. Currently these alternatives are coded into Roc and matches `web-app` and `web-app-react`.
 
 __template__
-Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a Github repo and can be anything matching that pattern `USERNAME/PROJECT`.
+Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a GitHub repo and can be anything matching that pattern `USERNAME/PROJECT`.
 
 The template can also point to a local zip file (ending in `.zip`) of a template repository. This is useful if the template is in a private repo or not available on GitHub.
 
 It will also expect that the template has a folder named `template` that contains a `package.json` file with at least one dependency to a Roc package following the pattern `roc-package-*` or that it has a `roc.config.js` file (this file is then expected to have some [packages](/docs/config/packages.md) defined but this is not checked immediately).
 
 __version__
-Versions should match a tag on the Github repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match Github default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
+Versions should match a tag on the GitHub repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match GitHub default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
 
 #### Arguments
 

--- a/test/documentation/fixtures/projects/empty/docs/Commands.md
+++ b/test/documentation/fixtures/projects/empty/docs/Commands.md
@@ -51,14 +51,14 @@ roc create init [template] [version]
 The __init__ command can be used to initiate a new Roc project and currently expects that it is run inside an empty directory. As shown above it takes two optional arguments, template and version. If no template is given a prompt will be displayed with the possible alternatives that exist. Currently these alternatives are coded into Roc and matches `web-app` and `web-app-react`.
 
 __template__
-Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a Github repo and can be anything matching that pattern `USERNAME/PROJECT`.
+Template can either be a short name for a specific template, currently it accepts `web-app` and `web-app-react` that will be converted internally to `rocjs/roc-template-web-app` and `rocjs/roc-template-web-app-react`. The actual template reference is a GitHub repo and can be anything matching that pattern `USERNAME/PROJECT`.
 
 The template can also point to a local zip file (ending in `.zip`) of a template repository. This is useful if the template is in a private repo or not available on GitHub.
 
 It will also expect that the template has a folder named `template` that contains a `package.json` file with at least one dependency to a Roc package following the pattern `roc-package-*` or that it has a `roc.config.js` file (this file is then expected to have some [packages](/docs/config/packages.md) defined but this is not checked immediately).
 
 __version__
-Versions should match a tag on the Github repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match Github default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
+Versions should match a tag on the GitHub repo and will default to master if none exists. When providing an input on the command line Roc will automatically add `v` in front of versions that starts with a number to match GitHub default conventions that have version tags that start with `v` like `v1.0.0`. `master` is also always available as an option.
 
 #### Arguments
 


### PR DESCRIPTION
Github →GitHub
'Selected a template' → 'Select a template'
