### PR TITLE
Builds relationship mapping between extensions and renders as a tree

### DIFF
--- a/docs/Context.md
+++ b/docs/Context.md
@@ -17,8 +17,8 @@ __Object structure__
   extensionConfig: {}, // The configuration before the user configuration is added
   hooks: {}, // All the registered hooks from the extensions
   meta: {}, // The meta configuration from the extensions
-  projectExtensions: [], // The extensions that the project directly depend on
   packageJSON: {}, // Content of the projects package.json
+  projectExtensions: [], // The extensions that the project directly depend on
   usedExtensions: [], // All the used extensions that are used, direct and indirect
   verbose: false/true // If the runtime is started in verbose mode or not
 }
@@ -143,6 +143,9 @@ Will be an object where the key is the extension that the hook belongs to and th
 An object with the merged meta configuration.
 
 The structure of the object is the same as the one used in the [Roc object](#config) with the exception for `__extensions` that Roc will add when building the context. This property is an array with strings that list all of the extensions that have modified it in some way. This is used in the core together with `override` to make sure that extensions knowingly override configuration defined by other extensions.
+
+### `packageJSON`
+The complete `package.json` for the extension.
 
 ### `projectExtensions`
 

--- a/docs/Context.md
+++ b/docs/Context.md
@@ -155,6 +155,7 @@ The structure of the object is the same as the one used in the [Roc object](#con
   standalone: roc.standalone,
   type: 'package' / 'plugin',
   version: roc.version,
+  parents: [{ name, version }, { name, version }, ...], // The parents that the extension have
 }]
 ```
 
@@ -169,6 +170,7 @@ The structure of the object is the same as the one used in the [Roc object](#con
   standalone: roc.standalone,
   type: 'package' / 'plugin',
   version: roc.version,
+  parents: [{ name, version }, { name, version }, ...], // The parents that the extension have
 }]
 ```
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "anchor-markdown-header": "0.5.5",
+    "archy": "1.0.0",
     "async": "2.0.1",
     "chalk": "~1.1.1",
     "colors": "~1.1.2",

--- a/src/context/extensions/steps/getExtensions.js
+++ b/src/context/extensions/steps/getExtensions.js
@@ -67,6 +67,7 @@ function getProjectExtension(type, extensionPath, state) {
                 standalone: roc.standalone,
                 type,
                 version: roc.version,
+                parents: getNearestParents(roc),
             });
 
             return nextState;
@@ -189,6 +190,19 @@ function getCompleteExtensionTree(type, roc, path, initialState) {
         (state, process) => process(roc, state),
         initialState
     );
+}
+
+function getNearestParents(roc) {
+    return [
+        ...(roc.packages || []),
+        ...(roc.plugins || []),
+    ].map((parent) => {
+        const { name, version } = getCompleteExtension(parent);
+        return {
+            name,
+            version,
+        };
+    });
 }
 
 function validateRocExtension(path) {
@@ -361,6 +375,7 @@ function registerExtension(type) {
                 standalone: roc.standalone,
                 type,
                 version: roc.version,
+                parents: roc.parents || getNearestParents(roc),
             });
         }
 


### PR DESCRIPTION
The new relations mapping is available on the context through `parents` on `usedExtensions` and `projectExtensions` and can be used to get the relationship between extensions. Roc uses it internally to render a tree representation of the extensions that a project uses when running in verbose mode.

![Extensions Tree](https://cloud.githubusercontent.com/assets/2854610/19720880/50c910c8-9b70-11e6-9ad0-a3d9eef31671.png)
