### PR TITLE
Changes the opt-out character from _ to #

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -52,13 +52,13 @@ With that said you could definitely use Yeoman together with Roc if you so wish.
 ### An extension is providing me with a dependency, I would like to you the local one in my project. How can I do this?
 There currently are two ways to disable exported dependencies from extensions.
 
-1. An easy way is to add a prefix, `_`, in front of the import to disable it from being managed by Roc.
+1. An easy way is to add a prefix, `#`, in front of the import to disable it from being managed by Roc.
 
 __Example__
 ```javascript
 import lodash from '_lodash';
 
-var lodash = require('_lodash');
+var lodash = require('#lodash');
 ```
 
 2. If a more permanent solution is desired it is possible to remove a dependecy all together through [the `init` function in `roc.config.js`](/docs/Configuration.md#init).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -49,14 +49,14 @@ Roc will push a lot of the code that you would normally get from a generator awa
 
 With that said you could definitely use Yeoman together with Roc if you so wish.
 
-### An extension is providing me with a dependency, I would like to you the local one in my project. How can I do this?
+### An extension is providing me with a dependency, I would like to use the local one in my project. How can I do this?
 There currently are two ways to disable exported dependencies from extensions.
 
 1. An easy way is to add a prefix, `#`, in front of the import to disable it from being managed by Roc.
 
 __Example__
 ```javascript
-import lodash from '_lodash';
+import lodash from '#lodash';
 
 var lodash = require('#lodash');
 ```

--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -39,8 +39,8 @@ It is possible to override the provided version if needed. Most of the time this
 ```javascript
 // Will use the react that has been installed in
 // the projects package.json and not the exported
-import React from '_react';
-var React = require('_react');
+import React from '#react';
+var React = require('#react');
 ```
 
 #### Uses

--- a/src/context/dependencies/verifyInstalledProjectDependencies.js
+++ b/src/context/dependencies/verifyInstalledProjectDependencies.js
@@ -24,7 +24,7 @@ export default function verifyInstalledProjectDependencies({ dependencies, devDe
 `You have some dependencies in your package.json that also have been exported by extensions. This is probably a mistake.
 
 ${underline('Roc will prioritize the ones exported by the extensions.')}
-You can override this by adding "_" to the start of the require/import in the code, see documentation for more info.
+You can override this by adding "#" to the start of the require/import in the code, see documentation for more info.
 
 Dependencies that is both exported and in the projects package.json:
 ${matches.map((match) => `- ${bold(match.name)} ${dim('from')} ` +

--- a/src/require/resolveRequest.js
+++ b/src/require/resolveRequest.js
@@ -36,7 +36,7 @@ export default function resolveRequest(exports, directory, dependencyContext) {
             }
 
             // Provides a way to opt-out of the Roc require system
-            if (request.charAt(0) === '_') {
+            if (request.charAt(0) === '#') {
                 return request.substring(1);
             }
 

--- a/test/require/resolveRequest.js
+++ b/test/require/resolveRequest.js
@@ -34,7 +34,7 @@ describe('roc', () => {
             const resolver = resolveRequest(exports, __dirname, dependencyContext)('Test');
 
             it('should bail out of opt-out character is used', () => {
-                expect(resolver('_a', __dirname))
+                expect(resolver('#a', __dirname))
                     .toEqual('a');
             });
 


### PR DESCRIPTION
### The change
This change is needed since we might have collisions with internal modules in Node otherwise, [as seen here](https://github.com/nodejs/node/tree/master/lib).

An example where this is a problem is in [`browserify-zlib`](https://github.com/devongovett/browserify-zlib/blob/master/src/index.js) that has the following code:
```js
var Transform = require('_stream_transform');
```

Roc will in some instances process this code through its resolver and the following branch will be true.
```js
// request = _stream_transform
if (request.charAt(0) === '_') {
   // stream_transform
   return request.substring(1);
}
```

This means that the code will now try to require `stream_transform` instead of the correct `_stream_transform`. This will then result in an error since this module does not exist.
```
ModuleNotFoundError: Module not found: Error: Cannot resolve module 'stream_transform' in /project/node_modules/browserify-zlib/src
```

This change means that opting out now is done in the following way.
```diff
-import React from '_react';
-var React = require('_react');
+import React from '#react';
+var React = require('#react');
```

### Question
Is the `#` a good character to use for opt-out? Is there a better alternative that we can use?