### PR TITLE
Encode template version

### DIFF
--- a/src/commands/init/fetchTemplate.js
+++ b/src/commands/init/fetchTemplate.js
@@ -146,7 +146,7 @@ function download(template, version, clone = false) {
 
     return new Promise((resolve) => {
         try {
-            downloadGitRepo(`${template}${version && '#' + version}`, tmp, { clone }, (error) => {
+            downloadGitRepo(`${template}${version && '#' + encodeURIComponent(version)}`, tmp, { clone }, (error) => {
                 if (error) {
                     spinner.fail();
                     log.error(


### PR DESCRIPTION
This fixes a bug where some characters in the branch name could make it impossible to download the template.