### PR TITLE
Pass filter to inquirer

### DIFF
--- a/src/commands/init/generateTemplate/ask.js
+++ b/src/commands/init/generateTemplate/ask.js
@@ -26,6 +26,7 @@ async function askQuestion(data, key, prompt) {
         default: prompt.default,
         choices: prompt.choices || [],
         validate: prompt.validate || (() => true),
+        filter: prompt.filter,
     }]);
 
     /* eslint-disable no-param-reassign */


### PR DESCRIPTION
Pretty much self-explanatory, I'd like to use `filter` option in Inquirer prompt from Roc.

Checked: Inquirer in version used in Roc supports this property ( https://github.com/SBoudrias/Inquirer.js/tree/v1.1.3#question )