### PR TITLE
Make template package.json optional

### DIFF
--- a/src/commands/init/index.js
+++ b/src/commands/init/index.js
@@ -70,8 +70,10 @@ export default async function init({
 
     // 5. Process template
     generateTemplate(folderName, templateDir, dir, () => {
-        // Copy & Rename the template package.json for history/documentation purposes
-        copySync(path.join(templateDir, 'package.json'), path.join(dir, '.roc'));
+        // Copy & Rename the template package.json if it exists, for history/documentation purposes
+        if (fileExists('package.json', templateDir)) {
+            copySync(path.join(templateDir, 'package.json'), path.join(dir, '.roc'));
+        }
     });
 }
 


### PR DESCRIPTION
Sometimes it doesn't make sense for template to have it's own package.json, so omit copying it if it's not present