### PR TITLE
Make it possible to pass data to templates

### DIFF
--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -161,6 +161,19 @@ The `prompts` property follows [Inquirer.js](https://github.com/SBoudrias/Inquir
 
 `name` and `author` are a bit special and will automatically default to the directory name and, if available, the name from the git config.
 
+#### `data`
+`data` property contains any arbitrary data you'd like to pass to templates. It supports both simple values and async functions / promises that eventually get resolved to values.
+Note that functions are supported only when using `.js` version of a config.
+
+```javascript
+{
+  "data": {
+    "version": "1.0.2",
+    "recentChanges": fetch("https://some-changelog.org/recent")
+  }
+}
+```
+
 ##### `when`
 It is possible to define conditional prompts that only will be shown in some instances.
 

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -161,19 +161,6 @@ The `prompts` property follows [Inquirer.js](https://github.com/SBoudrias/Inquir
 
 `name` and `author` are a bit special and will automatically default to the directory name and, if available, the name from the git config.
 
-#### `data`
-`data` property contains any arbitrary data you'd like to pass to templates. It supports both simple values and async functions / promises that eventually get resolved to values.
-Note that functions are supported only when using `.js` version of a config.
-
-```javascript
-{
-  "data": {
-    "version": "1.0.2",
-    "recentChanges": fetch("https://some-changelog.org/recent")
-  }
-}
-```
-
 ##### `when`
 It is possible to define conditional prompts that only will be shown in some instances.
 
@@ -199,6 +186,19 @@ It is possible to define conditional prompts that only will be shown in some ins
 ```
 
 The prompt for `testSetup` above will only be shown if the user answered yes to the `test` question.
+
+#### `data`
+`data` property contains any arbitrary data you'd like to pass to templates. It supports both simple values and async functions / promises that eventually get resolved to values.
+Note that functions are supported only when using `.js` version of a config.
+
+```javascript
+{
+  "data": {
+    "version": "1.0.2",
+    "recentChanges": () => fetch("https://some-changelog.org/recent")
+  }
+}
+```
 
 #### `filters`
 Filters can be useful to conditionally include files for the project based on answers from the prompt.

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -189,13 +189,13 @@ The prompt for `testSetup` above will only be shown if the user answered yes to 
 
 #### `data`
 `data` property contains any arbitrary data you'd like to pass to templates. It supports both simple values and async functions / promises that eventually get resolved to values.
-Note that functions are supported only when using `.js` version of a config.
+Note that functions are supported only when using `.js` version of a config. If you use function there it will receive an object containing collected answers as a parameter.
 
 ```javascript
 {
   "data": {
     "version": "1.0.2",
-    "recentChanges": () => fetch("https://some-changelog.org/recent")
+    "recentChanges": (answers) => fetch("https://some-changelog.org/recent")
   }
 }
 ```

--- a/src/commands/init/generateTemplate/collect.js
+++ b/src/commands/init/generateTemplate/collect.js
@@ -1,0 +1,23 @@
+export default async function(data, metadata, done) {
+    const keys = Object.getOwnPropertyNames(data);
+
+    for (const key of keys) {
+        await unwrap(metadata, key, data[key]);
+    }
+
+    done();
+}
+
+async function unwrap(metadata, key, dataProvider) {
+    /* eslint-disable no-param-reassign */
+    if (typeof dataProvider === 'function') {
+        try {
+            metadata[key] = await dataProvider();
+        } catch (e) {
+            // error in async function, leave this key
+        }
+        return;
+    }
+    metadata[key] = dataProvider;
+    /* eslint-enable */
+}

--- a/src/commands/init/generateTemplate/collect.js
+++ b/src/commands/init/generateTemplate/collect.js
@@ -12,7 +12,7 @@ async function unwrap(metadata, key, dataProvider) {
     /* eslint-disable no-param-reassign */
     if (typeof dataProvider === 'function') {
         try {
-            metadata[key] = await dataProvider();
+            metadata[key] = await dataProvider(metadata);
         } catch (e) {
             // error in async function, leave this key
         }

--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -8,6 +8,7 @@ import log from '../../../log/default/small';
 
 import getOptions from './options';
 import ask from './ask';
+import collect from './collect';
 import filter from './filter';
 
 const render = require('consolidate').handlebars.render;
@@ -43,6 +44,7 @@ export default function generateTemplate(name, src, dest, done) {
 
     metalsmith
         .use(askQuestions(opts.prompts))
+        .use(collectData(opts.data))
         .use(filterFiles(opts.filters))
         .use(renderTemplateFiles)
         .clean(false)
@@ -60,6 +62,10 @@ export default function generateTemplate(name, src, dest, done) {
 
 function askQuestions(prompts) {
     return (files, metalsmith, done) => ask(prompts, metalsmith.metadata(), done);
+}
+
+function collectData(data) {
+    return (files, metalsmith, done) => collect(data, metalsmith.metadata(), done);
 }
 
 function filterFiles(filters) {


### PR DESCRIPTION
This PR adds ability to pass additional data to templates that cannot or should not be obtained with questions.

My particular case is: I have a template inside of a module and I'd like to get that module's version from `package.json`.