### PR TITLE
Remove consolidate to avoid dependency collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "async": "2.0.1",
     "chalk": "~1.1.1",
     "colors": "~1.1.2",
-    "consolidate": "0.14.1",
     "cross-spawn": "2.2.3",
     "debug": "2.2.0",
     "download-git-repo": "0.1.2",

--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -11,8 +11,6 @@ import ask from './ask';
 import collect from './collect';
 import filter from './filter';
 
-const render = require('consolidate').handlebars.render;
-
 // Register default handlebars helper
 Handlebars.registerHelper('if_eq', (a, b, opts) => (
     a === b
@@ -70,6 +68,16 @@ function collectData(data) {
 
 function filterFiles(filters) {
     return (files, metalsmith, done) => filter(files, filters, metalsmith.metadata(), done);
+}
+
+function render(template, data, callback) {
+    let rendered;
+    try {
+        rendered = Handlebars.compile(template)(data);
+    } catch (e) {
+        return callback(e);
+    }
+    return callback(null, rendered);
 }
 
 function renderTemplateFiles(files, metalsmith, done) {


### PR DESCRIPTION
Closes #170 

Handlebars' API is synchronous but Consolidate's render is asynchronous, so I had to choose wether to rewrite all method calls to sync or mimic render as async. I've chosen the latter, because it doesn't require turning codebase upside down and leaves door open if at any point interface should be async again.