### PR TITLE
Pass data to Handlebars as options

### DIFF
--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -31,7 +31,6 @@ export default function generateTemplate(name, src, dest, done) {
         ...metalsmith.metadata(),
         destDirName: path.relative(process.cwd(), dest),
         inPlace: dest === process.cwd(),
-        noEscape: true,
     };
 
     if (opts.helpers) {
@@ -73,7 +72,7 @@ function filterFiles(filters) {
 function render(template, data, callback) {
     let rendered;
     try {
-        rendered = Handlebars.compile(template, data)(data);
+        rendered = Handlebars.compile(template, { noEscape: true })(data);
     } catch (e) {
         return callback(e);
     }

--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -73,7 +73,7 @@ function filterFiles(filters) {
 function render(template, data, callback) {
     let rendered;
     try {
-        rendered = Handlebars.compile(template)(data);
+        rendered = Handlebars.compile(template, data)(data);
     } catch (e) {
         return callback(e);
     }


### PR DESCRIPTION
FIxes regression introduced in #171 where `noEscape` was not passed into Handlebars anymore.