### PR TITLE
Prepopulate metalsmith metadata

### DIFF
--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -27,11 +27,10 @@ Handlebars.registerHelper('unless_eq', (a, b, opts) => (
 export default function generateTemplate(name, src, dest, done) {
     const opts = getOptions(name, src);
     const metalsmith = new Metalsmith(path.join(src, 'template'));
-    const data = {
-        ...metalsmith.metadata(),
+    metalsmith.metadata({
         destDirName: path.relative(process.cwd(), dest),
         inPlace: dest === process.cwd(),
-    };
+    });
 
     if (opts.helpers) {
         Object.keys(opts.helpers).forEach((key) => {
@@ -53,7 +52,7 @@ export default function generateTemplate(name, src, dest, done) {
             }
             log.success('Project created');
             done();
-            logMessage(opts.completionMessage, data);
+            logMessage(opts.completionMessage, metalsmith.metadata());
         });
 }
 

--- a/test/commands/init/generateTemplate/fixtures/alwaysSet/roc.setup.js
+++ b/test/commands/init/generateTemplate/fixtures/alwaysSet/roc.setup.js
@@ -1,0 +1,8 @@
+module.exports = {
+    prompts: {
+        hello: {
+            type: 'input',
+            required: true,
+        },
+    },
+};

--- a/test/commands/init/generateTemplate/fixtures/alwaysSet/template/test-input
+++ b/test/commands/init/generateTemplate/fixtures/alwaysSet/template/test-input
@@ -1,0 +1,3 @@
+{{{ hello }}}
+{{{ destDirName }}}
+{{{ inPlace }}}

--- a/test/commands/init/generateTemplate/index.js
+++ b/test/commands/init/generateTemplate/index.js
@@ -48,6 +48,23 @@ describe('commands', () => {
                         );
                     });
             });
+
+            it('should always supply destDirName and inPlace data to templates', () => {
+                const outputDir = join(__dirname, '_output', 'alwaysSet');
+                generateTemplate('hey', join(__dirname, 'fixtures', 'alwaysSet'), outputDir, () => {});
+
+                return answerPrompts([
+                    'something',
+                ])
+                    .then(() => readFile(join(outputDir, 'test-input')))
+                    .then(rendered => {
+                        expect(rendered).toBe(
+                            'something\n' +
+                            'test/commands/init/generateTemplate/_output/alwaysSet\n' +
+                            'false\n'
+                        );
+                    });
+            });
         });
     });
 });

--- a/test/commands/init/generateTemplate/index.js
+++ b/test/commands/init/generateTemplate/index.js
@@ -60,7 +60,7 @@ describe('commands', () => {
                     .then(rendered => {
                         expect(rendered).toBe(
                             'something\n' +
-                            'test/commands/init/generateTemplate/_output/alwaysSet\n' +
+                            join('test', 'commands', 'init', 'generateTemplate', '_output', 'alwaysSet') + '\n' +
                             'false\n'
                         );
                     });


### PR DESCRIPTION
Metalsmith's `metadata()` acts as a setter when it's passed an argument, so we can use that to prepopulate  data that will be used in templates and log function.