### PR TITLE
Fixed issue where some templates were not found

### DIFF
--- a/src/commands/init/githubHelpers.js
+++ b/src/commands/init/githubHelpers.js
@@ -1,7 +1,8 @@
 import got from 'got';
 
 export function getOfficialTemplates() {
-    return got('https://api.github.com/users/rocjs/repos', {
+    // TODO Implement pagination support before we reach over 100 repositories
+    return got('https://api.github.com/users/rocjs/repos?per_page=100', {
         json: true,
     })
     .then(response => response.body)


### PR DESCRIPTION
Mainly roc-template-web-app-react

This started to happen because we now have more than 30 repositories (31) which causes a pagination by default in the GitHub API. With this change we have increased this limit to 100 which will work for now and we will need to revisit this again soon to handle pagination more correctly for the future if we get more than 100 repositories.