### PR TITLE
Provide previous answers to inquirer

### DIFF
--- a/src/commands/init/generateTemplate/ask.js
+++ b/src/commands/init/generateTemplate/ask.js
@@ -19,12 +19,19 @@ async function askQuestion(data, key, prompt) {
         return;
     }
 
+    function withAnswers(entry) {
+        if (typeof entry === 'function') {
+            return entry(data);
+        }
+        return entry;
+    }
+
     const answers = await inquirer.prompt([{
         type: prompt.type,
         name: key,
-        message: prompt.message || key,
-        default: prompt.default,
-        choices: prompt.choices || [],
+        message: withAnswers(prompt.message) || key,
+        default: withAnswers(prompt.default),
+        choices: withAnswers(prompt.choices) || [],
         validate: prompt.validate || (() => true),
         filter: prompt.filter,
     }]);
@@ -38,3 +45,4 @@ async function askQuestion(data, key, prompt) {
     }
     /* eslint-enable */
 }
+

--- a/test/commands/init/generateTemplate/fixtures/previousAnswers/roc.setup.js
+++ b/test/commands/init/generateTemplate/fixtures/previousAnswers/roc.setup.js
@@ -1,0 +1,18 @@
+module.exports = {
+    prompts: {
+        hello: {
+            type: 'input',
+            required: true,
+        },
+        welcome: {
+            type: 'input',
+            default: (answers) => {
+                if (answers.hello === 'something') {
+                    return 'this should be a default';
+                }
+                return 'nope';
+            },
+            required: true,
+        },
+    },
+};

--- a/test/commands/init/generateTemplate/fixtures/previousAnswers/template/test-input
+++ b/test/commands/init/generateTemplate/fixtures/previousAnswers/template/test-input
@@ -1,0 +1,2 @@
+{{{ hello }}}
+{{{ welcome }}}

--- a/test/commands/init/generateTemplate/index.js
+++ b/test/commands/init/generateTemplate/index.js
@@ -65,6 +65,23 @@ describe('commands', () => {
                         );
                     });
             });
+
+            it('should allow to use previous answers when building prompts', () => {
+                const outputDir = join(__dirname, '_output', 'previousAnswers');
+                generateTemplate('hey', join(__dirname, 'fixtures', 'previousAnswers'), outputDir, () => {});
+
+                return answerPrompts([
+                    'something',
+                    '',
+                ])
+                    .then(() => readFile(join(outputDir, 'test-input')))
+                    .then(rendered => {
+                        expect(rendered).toBe(
+                            'something\n' +
+                            'this should be a default\n'
+                        );
+                    });
+            });
         });
     });
 });


### PR DESCRIPTION
Inquirer has an option to reference previous answers from the user, but in Roc internally every question is a new prompt, so this feature doesn't work (previous answers are always empty). This PR fixes it.