### PR TITLE
Fix condition blocks rendering for templates

### DIFF
--- a/src/commands/init/generateTemplate/index.js
+++ b/src/commands/init/generateTemplate/index.js
@@ -12,17 +12,17 @@ import collect from './collect';
 import filter from './filter';
 
 // Register default handlebars helper
-Handlebars.registerHelper('if_eq', (a, b, opts) => (
-    a === b
-    ? opts.fn(this)
-    : opts.inverse(this)
-));
+Handlebars.registerHelper('if_eq', function (a, b, opts) {
+    return a === b
+        ? opts.fn(this)
+        : opts.inverse(this);
+});
 
-Handlebars.registerHelper('unless_eq', (a, b, opts) => (
-    a === b
-    ? opts.inverse(this)
-    : opts.fn(this)
-));
+Handlebars.registerHelper('unless_eq', function (a, b, opts) {
+    return a === b
+        ? opts.inverse(this)
+        : opts.fn(this);
+});
 
 export default function generateTemplate(name, src, dest, done) {
     const opts = getOptions(name, src);

--- a/test/commands/init/generateTemplate/fixtures/inCondition/roc.setup.js
+++ b/test/commands/init/generateTemplate/fixtures/inCondition/roc.setup.js
@@ -1,0 +1,8 @@
+module.exports = {
+    prompts: {
+        hello: {
+            type: 'input',
+            required: true,
+        },
+    },
+};

--- a/test/commands/init/generateTemplate/fixtures/inCondition/template/test-input
+++ b/test/commands/init/generateTemplate/fixtures/inCondition/template/test-input
@@ -1,0 +1,1 @@
+{{#if_eq hello 'welcome'}}{{{ hello }}}{{/if_eq}}

--- a/test/commands/init/generateTemplate/index.js
+++ b/test/commands/init/generateTemplate/index.js
@@ -82,6 +82,21 @@ describe('commands', () => {
                         );
                     });
             });
+
+            it('should print values inside condition blocks', () => {
+                const outputDir = join(__dirname, '_output', 'inCondition');
+                generateTemplate('hey', join(__dirname, 'fixtures', 'inCondition'), outputDir, () => {});
+
+                return answerPrompts([
+                    'welcome',
+                ])
+                    .then(() => readFile(join(outputDir, 'test-input')))
+                    .then(rendered => {
+                        expect(rendered).toBe(
+                            'welcome\n'
+                        );
+                    });
+            });
         });
     });
 });


### PR DESCRIPTION
There's a bug in template rendering logic causing variables to disappear inside of condition blocks (`if_eq`, `unless_eq`). The reason for this is using `this` inside of lambda functions in helpers ([here](https://github.com/rocjs/roc/blob/v1.0.0-rc.22/src/commands/init/generateTemplate/index.js#L15)). This PR fixes that.